### PR TITLE
optimize tcp_check/statd/log

### DIFF
--- a/engine/health_check.go
+++ b/engine/health_check.go
@@ -123,10 +123,11 @@ func checkHTTP(ID string, backends []string, code int, timeout time.Duration) bo
 func checkTCP(ID string, backends []string, timeout time.Duration) bool {
 	for _, backend := range backends {
 		log.Debugf("[checkTCP] Check health via tcp: container %s, backend %s", ID, backend)
-		_, err := net.DialTimeout("tcp", backend, timeout)
+		conn, err := net.DialTimeout("tcp", backend, timeout)
 		if err != nil {
 			return false
 		}
+		conn.Close()
 	}
 	return true
 }

--- a/engine/logs/writer_test.go
+++ b/engine/logs/writer_test.go
@@ -1,6 +1,7 @@
 package logs
 
 import (
+	"encoding/json"
 	"net"
 	"testing"
 
@@ -19,6 +20,7 @@ func TestNewWriter(t *testing.T) {
 	assert.NoError(t, err)
 
 	w.conn = conn
+	w.encoder = json.NewEncoder(conn)
 	w.Write(&types.Log{
 		ID:   "testID",
 		Name: "hello",
@@ -38,5 +40,6 @@ func TestNewWriter(t *testing.T) {
 	assert.NoError(t, err)
 
 	w.conn = conn
+	w.encoder = json.NewEncoder(conn)
 	w.conn.Close()
 }


### PR DESCRIPTION
statsd/log forwarding
优化处理连接失败、中断等情况，并且不再频繁发起连接
这里为了提交日志转发的性能，设计上采用了异步重连（30秒重试间隔），并且设置状态位，已经在重连尝试中所有调用均会轮空（返回错误）

tcp_check
成功时会主动关闭连接，防止堆积连接数