### PR TITLE
cache node/container status to avoid too many writings to core

### DIFF
--- a/store/core/cache.go
+++ b/store/core/cache.go
@@ -1,0 +1,82 @@
+package corestore
+
+import (
+	"sync"
+	"time"
+)
+
+type item struct {
+	key      string
+	value    string
+	expireAt int64
+}
+
+func (i *item) expired() bool {
+	if i.expireAt == 0 {
+		return false
+	}
+	return time.Now().Unix() >= i.expireAt
+}
+
+// Cache is ... a cache
+// it will cleanup the expired items every interval time
+type Cache struct {
+	interval time.Duration
+	items    *sync.Map
+}
+
+func (c *Cache) cleanup() {
+	ticker := time.NewTicker(c.interval)
+	for range ticker.C {
+		c.cleanExpired()
+	}
+}
+
+func (c *Cache) cleanExpired() {
+	c.items.Range(func(key, value interface{}) bool {
+		i, ok := value.(*item)
+		if !ok || !i.expired() {
+			return true
+		}
+		c.items.Delete(key)
+		return true
+	})
+}
+
+// Put puts the key-value pair
+// will expire after expireAfter seconds
+// you can't put a key that never expires
+func (c *Cache) Put(key, value string, expireAfter int64) {
+	i := &item{
+		key:      key,
+		value:    value,
+		expireAt: time.Now().Unix() + expireAfter,
+	}
+	c.items.Store(key, i)
+}
+
+// Get gets the value of key
+// returns value and ok which represents if the key exists
+func (c *Cache) Get(key string) (string, bool) {
+	v, ok := c.items.Load(key)
+	if !ok {
+		return "", false
+	}
+
+	i, ok := v.(*item)
+	if !ok {
+		return "", false
+	}
+	return i.value, true
+}
+
+// NewCache returns a Cache
+// it will cleanup every interval seconds
+func NewCache(interval int) *Cache {
+	c := &Cache{
+		interval: time.Duration(interval) * time.Second,
+		items:    &sync.Map{},
+	}
+	go c.cleanup()
+	return c
+}

--- a/store/core/cache_test.go
+++ b/store/core/cache_test.go
@@ -1,0 +1,33 @@
+package corestore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCache(t *testing.T) {
+	a := assert.New(t)
+
+	var (
+		value string
+		ok    bool
+	)
+
+	cache := NewCache(1)
+	cache.Put("testkey", "testvalue", 1)
+
+	value, ok = cache.Get("keynonexists")
+	a.False(ok)
+	a.Equal(value, "")
+
+	value, ok = cache.Get("testkey")
+	a.True(ok)
+	a.Equal(value, "testvalue")
+
+	time.Sleep(3 * time.Second)
+	value, ok = cache.Get("testkey")
+	a.False(ok)
+	a.Equal(value, "")
+}

--- a/store/core/cache_test.go
+++ b/store/core/cache_test.go
@@ -26,6 +26,11 @@ func TestCache(t *testing.T) {
 	a.True(ok)
 	a.Equal(value, "testvalue")
 
+	cache.Put("testkey", "testvalue1", 1)
+	value, ok = cache.Get("testkey")
+	a.True(ok)
+	a.Equal(value, "testvalue1")
+
 	time.Sleep(3 * time.Second)
 	value, ok = cache.Get("testkey")
 	a.False(ok)

--- a/store/core/client.go
+++ b/store/core/client.go
@@ -1,18 +1,21 @@
 package corestore
 
 import (
-	"fmt"
-
 	"context"
+	"fmt"
 
 	"github.com/projecteru2/agent/types"
 	"github.com/projecteru2/core/client"
 )
 
+// cache will cleanup every 15 seconds
+const defaultCacheCleanupInterval = 15
+
 // CoreStore use core to store meta
 type CoreStore struct {
 	client *client.Client
 	config *types.Config
+	cache  *Cache
 }
 
 // NewClient new a client
@@ -21,5 +24,5 @@ func NewClient(ctx context.Context, config *types.Config) (*CoreStore, error) {
 		return nil, fmt.Errorf("Core addr not set")
 	}
 	coreClient, err := client.NewClient(ctx, config.Core, config.Auth)
-	return &CoreStore{coreClient, config}, err
+	return &CoreStore{coreClient, config, NewCache(defaultCacheCleanupInterval)}, err
 }

--- a/store/core/container.go
+++ b/store/core/container.go
@@ -1,29 +1,41 @@
 package corestore
 
 import (
-	"encoding/json"
-
 	"context"
+	"encoding/json"
 
 	"github.com/projecteru2/agent/types"
 	pb "github.com/projecteru2/core/rpc/gen"
 	coretypes "github.com/projecteru2/core/types"
 )
 
-// SetContainerStatus deploy containers
+// a hour to expire
+const defaultContainerStatusTTL = 3600
+
+// SetContainerStatus calls api of core to set status for a container
 func (c *CoreStore) SetContainerStatus(ctx context.Context, container *types.Container, node *coretypes.Node) error {
 	client := c.client.GetRPCClient()
 	bytes, err := json.Marshal(container.Labels)
 	if err != nil {
 		return err
 	}
+
 	containerStatus := &pb.WorkloadStatus{
 		Id:        container.ID,
 		Running:   container.Running,
 		Healthy:   container.Healthy,
 		Networks:  container.Networks,
 		Extension: bytes,
-		Ttl:       int64(2*c.config.HealthCheckStatusTTL + c.config.HealthCheckStatusTTL/2),
+		Ttl:       0,
+	}
+	pbs := containerStatus.String()
+	v, ok := c.cache.Get(container.ID)
+	if ok && pbs == v {
+		return nil
+	}
+
+	if !ok || pbs != v {
+		c.cache.Put(container.ID, pbs, defaultContainerStatusTTL)
 	}
 
 	opts := &pb.SetWorkloadsStatusOptions{

--- a/store/core/container.go
+++ b/store/core/container.go
@@ -34,10 +34,7 @@ func (c *CoreStore) SetContainerStatus(ctx context.Context, container *types.Con
 		return nil
 	}
 
-	if !ok || pbs != v {
-		c.cache.Put(container.ID, pbs, defaultContainerStatusTTL)
-	}
-
+	c.cache.Put(container.ID, pbs, defaultContainerStatusTTL)
 	opts := &pb.SetWorkloadsStatusOptions{
 		Status: []*pb.WorkloadStatus{containerStatus},
 	}


### PR DESCRIPTION
use `String` method provided by `protobuf` to serialize the option  
* if value is not found in the cache, should set value and do update
* if value is found but not equal to the current option, should set value and do update
* if value is found and equals to the current option, just ignore