### PR TITLE
container may be overrided to nil

### DIFF
--- a/engine/stat.go
+++ b/engine/stat.go
@@ -43,9 +43,10 @@ func (e *Engine) stat(parentCtx context.Context, container *types.Container) {
 	log.Infof("[stat] container %s %s metric report start", container.Name, coreutils.ShortID(container.ID))
 
 	updateMetrics := func() {
-		container, err = e.detectContainer(container.ID)
+		id := container.ID
+		container, err = e.detectContainer(id)
 		if err != nil {
-			log.Errorf("[stat] can not refresh container meta %s", container.ID)
+			log.Errorf("[stat] can not refresh container meta %s", id)
 			return
 		}
 		containerCPUCount := container.CPUNum * period


### PR DESCRIPTION
`detectContainer` may override `container` to `nil`

error log:

```
eru-agent[285413]: time="2021-02-26T12:52:27+08:00" level=info msg="[stat] container rediscluster fbb3da3 metric report stop"
eru-agent[285413]: panic: runtime error: invalid memory address or nil pointer dereference
eru-agent[285413]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xbcecdf]
eru-agent[285413]: goroutine 2365 [running]:
eru-agent[285413]: github.com/projecteru2/agent/engine.(*Engine).stat.func1()
eru-agent[285413]:         /home/runner/work/agent/agent/engine/stat.go:48 +0x163f
eru-agent[285413]: github.com/projecteru2/agent/engine.(*Engine).stat(0xc00052c120, 0x1400420, 0xc00843c640, 0x0)
eru-agent[285413]:         /home/runner/work/agent/agent/engine/stat.go:132 +0x6d4
eru-agent[285413]: created by github.com/projecteru2/agent/engine.(*Engine).attach
eru-agent[285413]:         /home/runner/work/agent/agent/engine/attach.go:65 +0x632
```