### PR TITLE
cleanup background context

### DIFF
--- a/agent.yaml.sample
+++ b/agent.yaml.sample
@@ -24,6 +24,8 @@ healthcheck:
   timeout: 10
   cache_ttl: 300
 
+global_connection_timeout: 15s
+
 etcd:
   machines:
     - 127.0.0.1:2379

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -129,7 +129,9 @@ func (e *Engine) crash() error {
 			return err
 		}
 		container.Healthy = false
-		if err := e.store.SetContainerStatus(context.Background(), container, e.node); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), e.config.GlobalConnectionTimeout)
+		defer cancel()
+		if err := e.store.SetContainerStatus(ctx, container, e.node); err != nil {
 			return err
 		}
 		log.Infof("[crash] mark %s unhealthy", coreutils.ShortID(container.ID))

--- a/engine/health_check.go
+++ b/engine/health_check.go
@@ -71,7 +71,9 @@ func (e *Engine) checkOneContainer(container *types.Container) {
 		container.Healthy = checkSingleContainerHealthy(container, timeout)
 	}
 
-	if err := e.store.SetContainerStatus(context.Background(), container, e.node); err != nil {
+	cctx, cancel := context.WithTimeout(context.Background(), e.config.GlobalConnectionTimeout)
+	defer cancel()
+	if err := e.store.SetContainerStatus(cctx, container, e.node); err != nil {
 		log.Errorf("[checkOneContainer] update deploy status failed %v", err)
 	}
 }

--- a/engine/load.go
+++ b/engine/load.go
@@ -26,7 +26,9 @@ func (e *Engine) load() error {
 			e.attach(c)
 		}
 
-		if err := e.store.SetContainerStatus(context.Background(), c, e.node); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), e.config.GlobalConnectionTimeout)
+		defer cancel()
+		if err := e.store.SetContainerStatus(ctx, c, e.node); err != nil {
 			log.Errorf("[load] update deploy status failed %v", err)
 		}
 	}

--- a/store/core/node.go
+++ b/store/core/node.go
@@ -10,7 +10,10 @@ import (
 // GetNode return a node by core
 func (c *CoreStore) GetNode(nodename string) (*types.Node, error) {
 	client := c.client.GetRPCClient()
-	resp, err := client.GetNode(context.Background(), &pb.GetNodeOptions{Nodename: nodename})
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.config.GlobalConnectionTimeout)
+	defer cancel()
+	resp, err := client.GetNode(ctx, &pb.GetNodeOptions{Nodename: nodename})
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +47,10 @@ func (c *CoreStore) UpdateNode(node *types.Node) error {
 	} else {
 		opts.StatusOpt = types.TriFalse
 	}
-	_, err := client.SetNode(context.Background(), opts)
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.config.GlobalConnectionTimeout)
+	defer cancel()
+	_, err := client.SetNode(ctx, opts)
 	return err
 }
 

--- a/types/config.go
+++ b/types/config.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"os"
+	"time"
 
 	coretypes "github.com/projecteru2/core/types"
 	log "github.com/sirupsen/logrus"
@@ -52,6 +53,8 @@ type Config struct {
 	Log         LogConfig
 	HealthCheck HealthCheckConfig    `yaml:"healcheck"`
 	Etcd        coretypes.EtcdConfig `yaml:"etcd"`
+
+	GlobalConnectionTimeout time.Duration `yaml:"global_connection_timeout" default:"5s"`
 }
 
 // PrepareConfig 从cli覆写并做准备


### PR DESCRIPTION
cleanup all `core` or `docker` rpc related context.
some of them are on purpose to be `context.Background()` so didn't change them.