### PR TITLE
[SPVR-67] add "yavirt" as a new runtime

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -79,7 +79,6 @@ func serve(c *cli.Context) error {
 		defer cancel()
 		if err := workloadManager.Run(ctx); err != nil {
 			log.Errorf("[agent] workload manager err: %v, exiting", err)
-			cancel()
 		}
 	}()
 

--- a/agent.yaml.sample
+++ b/agent.yaml.sample
@@ -43,10 +43,20 @@ auth:
 # docker.endpoint is the url that eru-agent will use to connect to.
 # This URL can be a tcp address like "tcp://10.233.10.14:2376",
 # or a unix socket file path like "unix:///var/run/docker/sock",
-# this option is required and has no default value, you must set it.
 # Note that this endpoint is usually the API URL of docker on local machine.
 docker:
   endpoint: unix:///var/run/docker.sock
+
+# yavirt defines yavirt config
+#
+# yavirt.endpoint is the url that eru-agent will use to connect to.
+# Workloads whose names match one of yavirt.skip_guest_report_regexps will not be checked by eru-agent.
+# This URL can be a grpc address like "grpc://127.0.0.1:9697",
+# Note that this endpoint is usually the API URL of docker on local machine.
+yavirt:
+  endpoint: grpc://127.0.0.1:9697
+  skip_guest_report_regexps:
+    - .+002
 
 # metrics defines where should eru-agent send metrics of containers to.
 #

--- a/common/common.go
+++ b/common/common.go
@@ -20,6 +20,8 @@ const (
 
 	// DockerRuntime use docker as runtime
 	DockerRuntime = "docker"
+	// YavirtRuntime use yavirt as runtime
+	YavirtRuntime = "yavirt"
 	// MocksRuntime use the mock runtime
 	MocksRuntime = "mocks"
 
@@ -32,4 +34,9 @@ const (
 	ETCDKV = "etcd"
 	// MocksKV use the mock KV
 	MocksKV = "mocks"
+
+	// ERUNodeName key of workload's name label
+	ERUNodeName = "eru.nodename"
+	// ERUCoreID key of workload's core ID label
+	ERUCoreID = "eru.coreid"
 )

--- a/common/error.go
+++ b/common/error.go
@@ -1,0 +1,6 @@
+package common
+
+import "errors"
+
+// ErrNotImplemented .
+var ErrNotImplemented = errors.New("not implemented")

--- a/common/error.go
+++ b/common/error.go
@@ -4,3 +4,9 @@ import "errors"
 
 // ErrNotImplemented .
 var ErrNotImplemented = errors.New("not implemented")
+
+// ErrConnecting means writer is in connecting status, waiting to be connected
+var ErrConnecting = errors.New("connecting")
+
+// ErrInvalidScheme .
+var ErrInvalidScheme = errors.New("invalid scheme")

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/projecteru2/core v0.0.0-20210618045145-314d3a292929
-	github.com/projecteru2/libyavirt v0.0.0-20210915071951-6b784e72977b
+	github.com/projecteru2/libyavirt v0.0.0-20210924065830-1db08f427e87
 	github.com/prometheus/client_golang v1.11.0
 	github.com/shirou/gopsutil v3.20.11+incompatible
 	github.com/sirupsen/logrus v1.7.0
@@ -25,5 +25,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.0.3 // indirect
 )
-
-replace github.com/projecteru2/libyavirt v0.0.0-20210915071951-6b784e72977b => github.com/DuodenumL/libyavirt v0.0.0-20210920103912-eb23e2ebc0c2

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/projecteru2/core v0.0.0-20210618045145-314d3a292929
+	github.com/projecteru2/libyavirt v0.0.0-20210915071951-6b784e72977b
 	github.com/prometheus/client_golang v1.11.0
 	github.com/shirou/gopsutil v3.20.11+incompatible
 	github.com/sirupsen/logrus v1.7.0
@@ -24,3 +25,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.0.3 // indirect
 )
+
+replace github.com/projecteru2/libyavirt v0.0.0-20210915071951-6b784e72977b => github.com/DuodenumL/libyavirt v0.0.0-20210916103342-42ef27937ebd

--- a/go.mod
+++ b/go.mod
@@ -26,4 +26,4 @@ require (
 	gotest.tools/v3 v3.0.3 // indirect
 )
 
-replace github.com/projecteru2/libyavirt v0.0.0-20210915071951-6b784e72977b => github.com/DuodenumL/libyavirt v0.0.0-20210916103342-42ef27937ebd
+replace github.com/projecteru2/libyavirt v0.0.0-20210915071951-6b784e72977b => github.com/DuodenumL/libyavirt v0.0.0-20210920103912-eb23e2ebc0c2

--- a/go.sum
+++ b/go.sum
@@ -23,12 +23,6 @@ github.com/CMGS/statsd v0.0.0-20160223095033-48c421b3c1ab h1:/Nl282MSyyUKtYA9gAU
 github.com/CMGS/statsd v0.0.0-20160223095033-48c421b3c1ab/go.mod h1:GJO3SGuPXm9A2hpQVV7/wlPr8oP9xxQluI8y99gQu60=
 github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53/go.mod h1:+3IMCy2vIlbG1XG/0ggNQv0SvxCAIpPM5b1nCz56Xno=
 github.com/CloudyKit/jet/v3 v3.0.0/go.mod h1:HKQPgSJmdK8hdoAbKUUWajkHyHo4RaU5rMdUywE7VMo=
-github.com/DuodenumL/libyavirt v0.0.0-20210916094922-4654b515f27e h1:JAAgD05awQUezAbPweS0Pqxru0K4ShXmmzHx3/DONp4=
-github.com/DuodenumL/libyavirt v0.0.0-20210916094922-4654b515f27e/go.mod h1:9/SNmdphwl12ubwihkRa9YtOozM6liYLDxsricra1mY=
-github.com/DuodenumL/libyavirt v0.0.0-20210916103342-42ef27937ebd h1:FLhHBlEH1ia6NMU/sW1m7KYLgpc9/4SF0hcPlEIbEQY=
-github.com/DuodenumL/libyavirt v0.0.0-20210916103342-42ef27937ebd/go.mod h1:9/SNmdphwl12ubwihkRa9YtOozM6liYLDxsricra1mY=
-github.com/DuodenumL/libyavirt v0.0.0-20210920103912-eb23e2ebc0c2 h1:O0RF0MccQgarcyTnkudd7+QK4uEaq6iwZEjn9s+dGgY=
-github.com/DuodenumL/libyavirt v0.0.0-20210920103912-eb23e2ebc0c2/go.mod h1:FOc+hWBMLsMrmx5p3/moizKeSomedZPNwB6LhS+kEnE=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Microsoft/go-winio v0.4.16-0.20201130162521-d1ffc52c7331 h1:3YnB7Hpmh1lPecPE8doMOtYCrMdrpedZOvxfuNES/Vk=
 github.com/Microsoft/go-winio v0.4.16-0.20201130162521-d1ffc52c7331/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
@@ -433,6 +427,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/projecteru2/core v0.0.0-20210618045145-314d3a292929 h1:utetQxBGS03TtC0vgkEHTYh5zXUoTRpWr0I3K8ObexI=
 github.com/projecteru2/core v0.0.0-20210618045145-314d3a292929/go.mod h1:Cmom68fvQs8uAA9AEjSXu6sTegObAtgPKJMEWQUoQ+Y=
 github.com/projecteru2/libyavirt v0.0.0-20210514093713-959b2e232319/go.mod h1:9/SNmdphwl12ubwihkRa9YtOozM6liYLDxsricra1mY=
+github.com/projecteru2/libyavirt v0.0.0-20210924065830-1db08f427e87 h1:iascQhtPjHmEpAJ2Vb+/EoD0dZ+G08G1PdYXeyez1+M=
+github.com/projecteru2/libyavirt v0.0.0-20210924065830-1db08f427e87/go.mod h1:FOc+hWBMLsMrmx5p3/moizKeSomedZPNwB6LhS+kEnE=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
@@ -849,7 +845,6 @@ google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3Iji
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.37.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
-google.golang.org/grpc v1.38.0 h1:/9BgsAsa5nWe26HqOlvlgJnqBuktYOLCgjCPqsa56W0=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.40.0 h1:AGJ0Ih4mHjSeibYkFGh1dD9KJ/eOtZ93I6hoHhukQ5Q=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
@@ -863,7 +858,6 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSR
 cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6AU=
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
+cloud.google.com/go v0.46.3 h1:AVXDdKsrtX33oR9fbCMu/+c1o8Ofjq6Ku/MInaLVg5Y=
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
@@ -13,6 +14,7 @@ cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2k
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
+github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -21,6 +23,10 @@ github.com/CMGS/statsd v0.0.0-20160223095033-48c421b3c1ab h1:/Nl282MSyyUKtYA9gAU
 github.com/CMGS/statsd v0.0.0-20160223095033-48c421b3c1ab/go.mod h1:GJO3SGuPXm9A2hpQVV7/wlPr8oP9xxQluI8y99gQu60=
 github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53/go.mod h1:+3IMCy2vIlbG1XG/0ggNQv0SvxCAIpPM5b1nCz56Xno=
 github.com/CloudyKit/jet/v3 v3.0.0/go.mod h1:HKQPgSJmdK8hdoAbKUUWajkHyHo4RaU5rMdUywE7VMo=
+github.com/DuodenumL/libyavirt v0.0.0-20210916094922-4654b515f27e h1:JAAgD05awQUezAbPweS0Pqxru0K4ShXmmzHx3/DONp4=
+github.com/DuodenumL/libyavirt v0.0.0-20210916094922-4654b515f27e/go.mod h1:9/SNmdphwl12ubwihkRa9YtOozM6liYLDxsricra1mY=
+github.com/DuodenumL/libyavirt v0.0.0-20210916103342-42ef27937ebd h1:FLhHBlEH1ia6NMU/sW1m7KYLgpc9/4SF0hcPlEIbEQY=
+github.com/DuodenumL/libyavirt v0.0.0-20210916103342-42ef27937ebd/go.mod h1:9/SNmdphwl12ubwihkRa9YtOozM6liYLDxsricra1mY=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Microsoft/go-winio v0.4.16-0.20201130162521-d1ffc52c7331 h1:3YnB7Hpmh1lPecPE8doMOtYCrMdrpedZOvxfuNES/Vk=
 github.com/Microsoft/go-winio v0.4.16-0.20201130162521-d1ffc52c7331/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
@@ -36,6 +42,7 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alexcesaro/statsd v2.0.0+incompatible h1:HG17k1Qk8V1F4UOoq6tx+IUoAbOcI5PHzzEUGeDD72w=
 github.com/alexcesaro/statsd v2.0.0+incompatible/go.mod h1:vNepIbQAiyLe1j480173M6NYYaAsGwEcvuDTU3OCUGY=
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
 github.com/alicebob/miniredis/v2 v2.14.3/go.mod h1:gquAfGbzn92jvtrSC69+6zZnwSODVXVpYDRaGhWaL6I=
@@ -47,6 +54,7 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
+github.com/benbjohnson/clock v1.0.3 h1:vkLuvpK4fmtSCuo60+yC63p7y0BmQ8gm5ZXGuBCJyXg=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -60,6 +68,7 @@ github.com/cenkalti/backoff/v4 v4.0.2 h1:JIufpQLbh4DkbQoii76ItQIUFzevQSqOLZca4ea
 github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
+github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054 h1:uH66TXeswKn5PW5zdZ39xEwfS9an067BirqA+P4QaLI=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -72,8 +81,11 @@ github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3/go.mod h1:MA5e5Lr8slmE
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5 h1:xD/lrqdvwsc+O2bjSSi3YqY73Ke3LAiSCx49aCesA0E=
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
+github.com/cockroachdb/errors v1.2.4 h1:Lap807SXTH5tri2TivECb/4abUkMZC9zRoLarvcKDqs=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
+github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59/go.mod h1:pA0z1pT8KYB3TCXK/ocprsh7MAkoW8bZVzPdih9snmM=
@@ -150,6 +162,7 @@ github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoD
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
+github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/getsentry/sentry-go v0.9.0 h1:KIfpY/D9hX3gWAEd3d8z6ImuHNWtqEsjlpdF8zXFsHM=
 github.com/getsentry/sentry-go v0.9.0/go.mod h1:kELm/9iCblqUYh+ZRML7PNdCvEuw24wBvJPYyi86cws=
@@ -158,6 +171,7 @@ github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NB
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
+github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
 github.com/go-git/go-billy/v5 v5.0.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
@@ -226,6 +240,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -238,6 +253,7 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
@@ -322,6 +338,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/labstack/echo/v4 v4.1.11/go.mod h1:i541M3Fj6f76NZtHSj7TXnyM8n2gaodfvfxNnFqi74g=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
@@ -350,6 +367,7 @@ github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:F
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/moby/sys/mount v0.2.0/go.mod h1:aAivFE2LB3W4bACsUXChRHQ0qKWsetY4Y9V7sxOougM=
 github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
+github.com/moby/term v0.0.0-20201110203204-bea5bbe245bf h1:Un6PNx5oMK6CCwO3QTUyPiK2mtZnPrpDl5UnZ64eCkw=
 github.com/moby/term v0.0.0-20201110203204-bea5bbe245bf/go.mod h1:FBS0z0QWA44HXygs7VXDUOGoN/1TV3RuWkLO04am3wc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
@@ -357,6 +375,7 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
 github.com/muroq/redislock v0.0.0-20210327061935-5425e33e6f9f/go.mod h1:1ghhEkSF/jdbCML9bmr+3IbET6zO9HRh+xaxJuSPr2k=
@@ -366,6 +385,7 @@ github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5Vgl
 github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzEE/Zbp4w=
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -395,6 +415,7 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -563,6 +584,7 @@ go.opentelemetry.io/otel/metric v0.19.0/go.mod h1:8f9fglJPRnXuskQmKpnad31lcLJ2Vm
 go.opentelemetry.io/otel/metric v0.20.0 h1:4kzhXFP+btKm4jwxpjIqjs41A7MakRFUS86bqLHTIw8=
 go.opentelemetry.io/otel/metric v0.20.0/go.mod h1:598I5tYlH1vzBjn+BTuhzTCSb/9debfNp6R3s7Pr1eU=
 go.opentelemetry.io/otel/oteltest v0.19.0/go.mod h1:tI4yxwh8U21v7JD6R3BcA/2+RBoTKFexE/PJ/nSO7IA=
+go.opentelemetry.io/otel/oteltest v0.20.0 h1:HiITxCawalo5vQzdHfKeZurV8x7ljcqAgiWzF6Vaeaw=
 go.opentelemetry.io/otel/oteltest v0.20.0/go.mod h1:L7bgKf9ZB7qCwT9Up7i9/pn0PWIa9FqQ2IQ8LoxiGnw=
 go.opentelemetry.io/otel/sdk v0.20.0 h1:JsxtGXd06J8jrnya7fdI/U/MR6yXA5DtbZy+qoHQlr8=
 go.opentelemetry.io/otel/sdk v0.20.0/go.mod h1:g/IcepuwNsoiX5Byy2nNV0ySUF1em498m7hBWC279Yc=
@@ -580,6 +602,7 @@ go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/automaxprocs v1.3.0 h1:II28aZoGdaglS5vVNnspf28lnZpXScxtIozx1lAjdb0=
 go.uber.org/automaxprocs v1.3.0/go.mod h1:9CWT6lKIep8U41DDaPiH6eFscnTyjfTANNQNx6LrIcA=
+go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
@@ -669,6 +692,7 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BGiEpg5IG2JkU5FkPIawgtw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -793,6 +817,7 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
+google.golang.org/appengine v1.6.3 h1:hvZejVcIxAKHR8Pq2gXaDggf6CWT1QEqO+JEBeOKCG8=
 google.golang.org/appengine v1.6.3/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -839,6 +864,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
@@ -867,8 +893,10 @@ gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
+gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/DuodenumL/libyavirt v0.0.0-20210916094922-4654b515f27e h1:JAAgD05awQU
 github.com/DuodenumL/libyavirt v0.0.0-20210916094922-4654b515f27e/go.mod h1:9/SNmdphwl12ubwihkRa9YtOozM6liYLDxsricra1mY=
 github.com/DuodenumL/libyavirt v0.0.0-20210916103342-42ef27937ebd h1:FLhHBlEH1ia6NMU/sW1m7KYLgpc9/4SF0hcPlEIbEQY=
 github.com/DuodenumL/libyavirt v0.0.0-20210916103342-42ef27937ebd/go.mod h1:9/SNmdphwl12ubwihkRa9YtOozM6liYLDxsricra1mY=
+github.com/DuodenumL/libyavirt v0.0.0-20210920103912-eb23e2ebc0c2 h1:O0RF0MccQgarcyTnkudd7+QK4uEaq6iwZEjn9s+dGgY=
+github.com/DuodenumL/libyavirt v0.0.0-20210920103912-eb23e2ebc0c2/go.mod h1:FOc+hWBMLsMrmx5p3/moizKeSomedZPNwB6LhS+kEnE=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Microsoft/go-winio v0.4.16-0.20201130162521-d1ffc52c7331 h1:3YnB7Hpmh1lPecPE8doMOtYCrMdrpedZOvxfuNES/Vk=
 github.com/Microsoft/go-winio v0.4.16-0.20201130162521-d1ffc52c7331/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
@@ -81,6 +83,7 @@ github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3/go.mod h1:MA5e5Lr8slmE
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5 h1:xD/lrqdvwsc+O2bjSSi3YqY73Ke3LAiSCx49aCesA0E=
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4 h1:Lap807SXTH5tri2TivECb/4abUkMZC9zRoLarvcKDqs=
@@ -150,6 +153,7 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/etcd-io/gofail v0.0.0-20190801230047-ad7f989257ca/go.mod h1:49H/RkXP8pKaZy4h0d+NW16rSLhyVBt4o6VLJbmOqDE=
@@ -847,6 +851,8 @@ google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAG
 google.golang.org/grpc v1.37.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.38.0 h1:/9BgsAsa5nWe26HqOlvlgJnqBuktYOLCgjCPqsa56W0=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
+google.golang.org/grpc v1.40.0 h1:AGJ0Ih4mHjSeibYkFGh1dD9KJ/eOtZ93I6hoHhukQ5Q=
+google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -859,6 +865,8 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
+google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/logs/writer.go
+++ b/logs/writer.go
@@ -1,8 +1,8 @@
 package logs
 
 import (
+	"context"
 	"errors"
-	"fmt"
 	"net"
 	"net/url"
 	"sync"
@@ -17,16 +17,25 @@ import (
 const Discard = "__discard__"
 
 // ErrConnecting means writer is in connecting status, waiting to be connected
-var ErrConnecting = errors.New("Connecting")
+var ErrConnecting = errors.New("connecting")
+
+// ErrInvalidScheme .
+var ErrInvalidScheme = errors.New("invalid scheme")
+
+// KeepaliveInterval .
+var KeepaliveInterval = time.Second * 30
+
+// CloseWaitInterval .
+var CloseWaitInterval = time.Second * 5
 
 // Writer is a writer!
 type Writer struct {
 	sync.RWMutex
-	addr       string
-	scheme     string
-	connecting bool
-	stdout     bool
-	enc        Encoder
+	addr          string
+	scheme        string
+	stdout        bool
+	enc           Encoder
+	needReconnect bool
 }
 
 type discard struct {
@@ -43,20 +52,34 @@ func (d discard) Close() error {
 }
 
 // NewWriter return writer
-func NewWriter(addr string, stdout bool) (*Writer, error) {
+func NewWriter(ctx context.Context, addr string, stdout bool) (writer *Writer, err error) {
 	if addr == Discard {
 		return &Writer{
-			enc: NewStreamEncoder(discard{}),
+			enc:    NewStreamEncoder(discard{}),
 		}, nil
 	}
+
 	u, err := url.Parse(addr)
 	if err != nil {
 		return nil, err
 	}
-	writer := &Writer{addr: u.Host, scheme: u.Scheme, stdout: stdout}
-	// pre-connect and ignore error
-	_ = writer.checkConn()
-	return writer, err
+
+	writer = &Writer{addr: u.Host, scheme: u.Scheme, stdout: stdout}
+	writer.enc, err = writer.createEncoder()
+
+	if err == ErrInvalidScheme {
+		log.Infof("[writer] create an empty writer for %s success", addr)
+		writer.enc = NewStreamEncoder(discard{})
+	} else if err != nil {
+		log.Errorf("[writer] failed to create writer encoder for %s, err: %v, will retry", addr, err)
+		writer.needReconnect = true
+	} else {
+		log.Infof("[writer] create writer for %s success", addr)
+	}
+
+	go writer.keepalive(ctx)
+
+	return writer, nil
 }
 
 func (w *Writer) withLock(f func()) {
@@ -69,88 +92,6 @@ func (w *Writer) withRLock(f func()) {
 	w.RLock()
 	defer w.RUnlock()
 	f()
-}
-
-// CreateConn create conn
-func (w *Writer) createEncoder() (enc Encoder, err error) {
-	switch w.scheme {
-	case "udp":
-		enc, err = w.createUDPEncoder()
-	case "tcp":
-		enc, err = w.createTCPEncoder()
-	case "journal":
-		enc, err = CreateJournalEncoder()
-	default:
-		err = fmt.Errorf("[writer] Invalid scheme: %s", w.scheme)
-	}
-	return enc, err
-}
-
-func (w *Writer) checkError(err error) {
-	if err != nil && err != ErrConnecting {
-		log.Errorf("[writer] Sending log failed %s", err)
-		w.withLock(func() {
-			if w.enc != nil {
-				w.enc.Close()
-				w.enc = nil
-			}
-		})
-	}
-}
-
-func (w *Writer) checkConn() error {
-	var err error
-	w.withLock(func() {
-		if w.enc != nil {
-			// normal
-			return
-		}
-		if w.connecting {
-			err = ErrConnecting
-			return
-		}
-		w.connecting = true
-	})
-
-	go func() {
-		log.Debugf("[writer] Begin trying to connect to %s", w.addr)
-		// retrying up to 4 times to prevent infinite loop
-		for i := 0; i < 4; i++ {
-			enc, err := w.createEncoder()
-			if err == nil {
-				w.withLock(func() {
-					w.enc = enc
-					w.connecting = false
-				})
-				log.Debugf("[writer] Connect to %s successfully", w.addr)
-				return
-			}
-			log.Warnf("[writer] Failed to connect to %s: %s", w.addr, err)
-			time.Sleep(30 * time.Second)
-		}
-		w.connecting = false
-	}()
-	return err
-}
-
-// Write write log to remote
-func (w *Writer) Write(logline *types.Log) error {
-	if w.stdout {
-		log.Info(logline)
-	}
-	if len(w.addr) == 0 && len(w.scheme) == 0 {
-		return nil
-	}
-	var err error
-	err = w.checkConn()
-	if err == nil {
-		w.withRLock(func() {
-			err = w.enc.Encode(logline)
-		})
-	}
-
-	w.checkError(err)
-	return err
 }
 
 func (w *Writer) createUDPEncoder() (Encoder, error) {
@@ -175,4 +116,115 @@ func (w *Writer) createTCPEncoder() (Encoder, error) {
 		return nil, err
 	}
 	return NewStreamEncoder(conn), nil
+}
+
+// CreateConn create conn
+func (w *Writer) createEncoder() (enc Encoder, err error) {
+	switch w.scheme {
+	case "udp":
+		enc, err = w.createUDPEncoder()
+	case "tcp":
+		enc, err = w.createTCPEncoder()
+	case "journal":
+		enc, err = CreateJournalEncoder()
+	default:
+		log.Errorf("[writer] Invalid scheme: %s", w.scheme)
+		err = ErrInvalidScheme
+	}
+	return enc, err
+}
+
+func (w *Writer) reconnect() {
+	needReconnect := false
+	w.withRLock(func() {
+		needReconnect = w.needReconnect
+	})
+	if !needReconnect {
+		return
+	}
+
+	log.Debugf("[writer] Reconnecting to %s...", w.addr)
+	enc, err := w.createEncoder()
+	if err == nil {
+		w.withLock(func() {
+			w.enc = enc
+			w.needReconnect = false
+		})
+		log.Debugf("[writer] Connect to %s successfully", w.addr)
+		return
+	}
+	log.Warnf("[writer] Failed to connect to %s: %s", w.addr, err)
+}
+
+func (w *Writer) keepalive(ctx context.Context) {
+	timer := time.NewTimer(KeepaliveInterval)
+	for {
+		select {
+		case <-timer.C:
+			w.reconnect()
+			timer.Reset(KeepaliveInterval)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (w *Writer) checkError(err error) {
+	if err != nil && err != ErrConnecting {
+		log.Errorf("[writer] Sending log failed %s", err)
+		w.withLock(func() {
+			if w.enc != nil {
+				w.enc.Close()
+				w.enc = nil
+				w.needReconnect = true
+			}
+		})
+	}
+}
+
+func (w *Writer) checkConn() error {
+	var err error
+	w.withLock(func() {
+		if w.enc == nil {
+			err = ErrConnecting
+			w.needReconnect = true
+		}
+	})
+
+	return err
+}
+
+// Write write log to remote
+func (w *Writer) Write(logline *types.Log) error {
+	if w.stdout {
+		log.Info(logline)
+	}
+	if len(w.addr) == 0 && len(w.scheme) == 0 {
+		return nil
+	}
+	var err error
+	err = w.checkConn()
+	if err == nil {
+		w.withRLock(func() {
+			err = w.enc.Encode(logline)
+		})
+	}
+
+	w.checkError(err)
+	return err
+}
+
+// Close .
+func (w *Writer) Close() error {
+	// leave some time for the pending writing
+	time.Sleep(CloseWaitInterval)
+	var err error
+	w.withLock(func() {
+		if w.enc != nil {
+			err = w.enc.Close()
+			w.enc = nil
+		}
+	})
+	log.Infof("[writer] writer for %s closed", w.addr)
+	return err
 }

--- a/logs/writer.go
+++ b/logs/writer.go
@@ -138,6 +138,9 @@ func (w *Writer) Write(logline *types.Log) error {
 	if w.stdout {
 		log.Info(logline)
 	}
+	if len(w.addr) == 0 && len(w.scheme) == 0 {
+		return nil
+	}
 	var err error
 	err = w.checkConn()
 	if err == nil {

--- a/logs/writer.go
+++ b/logs/writer.go
@@ -55,7 +55,7 @@ func (d discard) Close() error {
 func NewWriter(ctx context.Context, addr string, stdout bool) (writer *Writer, err error) {
 	if addr == Discard {
 		return &Writer{
-			enc:    NewStreamEncoder(discard{}),
+			enc: NewStreamEncoder(discard{}),
 		}, nil
 	}
 
@@ -67,13 +67,14 @@ func NewWriter(ctx context.Context, addr string, stdout bool) (writer *Writer, e
 	writer = &Writer{addr: u.Host, scheme: u.Scheme, stdout: stdout}
 	writer.enc, err = writer.createEncoder()
 
-	if err == ErrInvalidScheme {
+	switch {
+	case err == ErrInvalidScheme:
 		log.Infof("[writer] create an empty writer for %s success", addr)
 		writer.enc = NewStreamEncoder(discard{})
-	} else if err != nil {
+	case err != nil:
 		log.Errorf("[writer] failed to create writer encoder for %s, err: %v, will retry", addr, err)
 		writer.needReconnect = true
-	} else {
+	default:
 		log.Infof("[writer] create writer for %s success", addr)
 	}
 

--- a/logs/writer_test.go
+++ b/logs/writer_test.go
@@ -40,7 +40,7 @@ func TestNewWriterWithTCP(t *testing.T) {
 	w.withLock(func() {
 		w.enc = enc
 	})
-	assert.NoError(t, w.enc.Encode(&types.Log{}))
+	assert.NoError(t, w.Write(&types.Log{}))
 }
 
 // func TestNewWriterWithJournal(t *testing.T) {

--- a/logs/writer_test.go
+++ b/logs/writer_test.go
@@ -1,6 +1,7 @@
 package logs
 
 import (
+	"context"
 	"net"
 	"testing"
 
@@ -10,9 +11,11 @@ import (
 )
 
 func TestNewWriterWithUDP(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	// udp writer
 	addr := "udp://127.0.0.1:23456"
-	w, err := NewWriter(addr, true)
+	w, err := NewWriter(ctx, addr, true)
 	assert.NoError(t, err)
 
 	enc, err := w.createUDPEncoder()
@@ -25,13 +28,15 @@ func TestNewWriterWithUDP(t *testing.T) {
 }
 
 func TestNewWriterWithTCP(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	// tcp writer
 	addr := "tcp://127.0.0.1:34567"
 	tcpL, err := net.Listen("tcp", ":34567")
 	assert.NoError(t, err)
 
 	defer tcpL.Close()
-	w, err := NewWriter(addr, true)
+	w, err := NewWriter(ctx, addr, true)
 	assert.NoError(t, err)
 
 	enc, err := w.createTCPEncoder()

--- a/manager/node/heartbeat.go
+++ b/manager/node/heartbeat.go
@@ -40,7 +40,7 @@ func (m *Manager) nodeStatusReport(ctx context.Context) {
 	defer log.Debug("[nodeStatusReport] report ends")
 
 	if !m.runtimeClient.IsDaemonRunning(ctx) {
-		log.Debugf("[nodeStatusReport] cannot connect to runtime daemon")
+		log.Debug("[nodeStatusReport] cannot connect to runtime daemon")
 		return
 	}
 

--- a/manager/node/heartbeat_test.go
+++ b/manager/node/heartbeat_test.go
@@ -2,10 +2,9 @@ package node
 
 import (
 	"context"
-	"testing"
-
 	runtimemocks "github.com/projecteru2/agent/runtime/mocks"
 	storemocks "github.com/projecteru2/agent/store/mocks"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/manager/node/heartbeat_test.go
+++ b/manager/node/heartbeat_test.go
@@ -2,9 +2,10 @@ package node
 
 import (
 	"context"
+	"testing"
+
 	runtimemocks "github.com/projecteru2/agent/runtime/mocks"
 	storemocks "github.com/projecteru2/agent/store/mocks"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/manager/node/manager.go
+++ b/manager/node/manager.go
@@ -75,7 +75,7 @@ func NewManager(ctx context.Context, config *types.Config) (*Manager, error) {
 
 // Run runs a node manager
 func (m *Manager) Run(ctx context.Context) error {
-	log.Infof("[NodeManager] start node status heartbeat")
+	log.Info("[NodeManager] start node status heartbeat")
 	go m.heartbeat(ctx)
 
 	// wait for signal

--- a/manager/node/manager.go
+++ b/manager/node/manager.go
@@ -80,6 +80,10 @@ func (m *Manager) Run(ctx context.Context) error {
 
 	// wait for signal
 	<-ctx.Done()
+	return m.exit()
+}
+
+func (m *Manager) exit() error {
 	log.Info("[NodeManager] exiting")
 	log.Infof("[NodeManager] mark node %s as down", m.config.HostName)
 

--- a/manager/node/manager.go
+++ b/manager/node/manager.go
@@ -8,6 +8,7 @@ import (
 	"github.com/projecteru2/agent/runtime"
 	"github.com/projecteru2/agent/runtime/docker"
 	runtimemocks "github.com/projecteru2/agent/runtime/mocks"
+	"github.com/projecteru2/agent/runtime/yavirt"
 	"github.com/projecteru2/agent/store"
 	corestore "github.com/projecteru2/agent/store/core"
 	storemocks "github.com/projecteru2/agent/store/mocks"
@@ -54,6 +55,12 @@ func NewManager(ctx context.Context, config *types.Config) (*Manager, error) {
 		}
 		docker.InitClient(config, nodeIP)
 		m.runtimeClient = docker.GetClient()
+		if m.runtimeClient == nil {
+			return nil, errors.New("failed to get runtime client")
+		}
+	case common.YavirtRuntime:
+		yavirt.InitClient(config)
+		m.runtimeClient = yavirt.GetClient()
 		if m.runtimeClient == nil {
 			return nil, errors.New("failed to get runtime client")
 		}

--- a/manager/workload/attach.go
+++ b/manager/workload/attach.go
@@ -30,9 +30,6 @@ func (m *Manager) attach(ctx context.Context, ID string) {
 		log.Errorf("[attach] Create log forward %s failed %s", transfer, err)
 		return
 	}
-	defer func() {
-		go writer.Close()
-	}()
 
 	// get app info
 	workloadName, err := m.runtimeClient.GetWorkloadName(ctx, ID)

--- a/manager/workload/attach.go
+++ b/manager/workload/attach.go
@@ -37,7 +37,7 @@ func (m *Manager) attach(ctx context.Context, ID string) {
 		if err != common.ErrNotImplemented {
 			log.Errorf("[attach] failed to get workload name, id: %v, err: %v", ID, err)
 		} else {
-			log.Debugf("[attach] should ignore this workload")
+			log.Debug("[attach] should ignore this workload")
 		}
 		return
 	}

--- a/manager/workload/attach.go
+++ b/manager/workload/attach.go
@@ -67,12 +67,15 @@ func (m *Manager) attach(ctx context.Context, ID string) {
 	wg := &sync.WaitGroup{}
 	pump := func(typ string, source io.Reader) {
 		defer wg.Done()
+		log.Debugf("[attach] attach pump %s %s %s start", workloadName, ID, typ)
+		defer log.Debugf("[attach] attach pump %s %s %s finished", workloadName, ID, typ)
+
 		buf := bufio.NewReader(source)
 		for {
 			data, err := buf.ReadString('\n')
 			if err != nil {
 				if err != io.EOF {
-					log.Errorf("[attach] attach pump %s %s %s %s", workloadName, ID, typ, err)
+					log.Errorf("[attach] attach pump %s %s %s failed, err: %v", workloadName, ID, typ, err)
 				}
 				return
 			}

--- a/manager/workload/event.go
+++ b/manager/workload/event.go
@@ -33,7 +33,7 @@ func (e *EventHandler) Watch(ctx context.Context, c <-chan *types.WorkloadEventM
 		select {
 		case ev, ok := <-c:
 			if !ok {
-				log.Infof("[Watch] event chan closed")
+				log.Info("[Watch] event chan closed")
 				return
 			}
 			log.Infof("[Watch] Monitor: workload id %s action %s", ev.ID, ev.Action)
@@ -44,7 +44,7 @@ func (e *EventHandler) Watch(ctx context.Context, c <-chan *types.WorkloadEventM
 			}
 			e.Unlock()
 		case <-ctx.Done():
-			log.Infof("[Watch] context canceled, stop watching")
+			log.Info("[Watch] context canceled, stop watching")
 			return
 		}
 	}

--- a/manager/workload/event.go
+++ b/manager/workload/event.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/projecteru2/agent/types"
-	coreutils "github.com/projecteru2/core/utils"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -31,7 +30,7 @@ func (e *EventHandler) Handle(action string, h func(context.Context, *types.Work
 // Watch watch change
 func (e *EventHandler) Watch(ctx context.Context, c <-chan *types.WorkloadEventMessage) {
 	for ev := range c {
-		log.Infof("[Watch] Monitor: workload id %s action %s", coreutils.ShortID(ev.ID), ev.Action)
+		log.Infof("[Watch] Monitor: workload id %s action %s", ev.ID, ev.Action)
 		e.Lock()
 		h := e.handlers[ev.Action]
 		if h != nil {

--- a/manager/workload/event_test.go
+++ b/manager/workload/event_test.go
@@ -13,18 +13,17 @@ import (
 )
 
 func TestEvent(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	manager := newMockWorkloadManager(t)
 	runtime := manager.runtimeClient.(*runtimemocks.Nerv)
 	store := manager.store.(*storemocks.MockStore)
 	// init workload status
-	assert.Nil(t, manager.load(ctx))
+	assert.Nil(t, manager.initWorkloadStatus(ctx))
 	assertInitStatus(t, store)
 
-	// errChan is useless here
-	msgChan, _ := manager.initMonitor(ctx)
-	go manager.monitor(ctx, msgChan)
+	go manager.monitor(ctx)
 
 	// starts the events: Shinji 400%, Asuka starts, Asuka dies, Rei dies
 	go runtime.StartEvents()

--- a/manager/workload/filter.go
+++ b/manager/workload/filter.go
@@ -1,26 +1,29 @@
 package workload
 
 import (
-	"fmt"
+	"sync"
 
-	"github.com/projecteru2/agent/types"
+	"github.com/projecteru2/agent/common"
 	"github.com/projecteru2/agent/utils"
 	"github.com/projecteru2/core/cluster"
 )
 
-func (m *Manager) getFilter(extend map[string]string) []types.KV {
-	var f []types.KV
-	f = append(f, types.KV{Key: "label", Value: fmt.Sprintf("%s=1", cluster.ERUMark)})
+var filter map[string]string
+var once sync.Once
 
-	if m.config.CheckOnlyMine && utils.UseLabelAsFilter() {
-		f = append(f, types.KV{Key: "label", Value: fmt.Sprintf("eru.nodename=%s", m.config.HostName)})
-		if m.storeIdentifier != "" {
-			f = append(f, types.KV{Key: "label", Value: fmt.Sprintf("eru.coreid=%s", m.storeIdentifier)})
+func (m *Manager) getBaseFilter() map[string]string {
+	once.Do(func() {
+		filter = map[string]string{
+			cluster.ERUMark: "1",
 		}
-	}
 
-	for k, v := range extend {
-		f = append(f, types.KV{Key: k, Value: v})
-	}
-	return f
+		if m.config.CheckOnlyMine && utils.UseLabelAsFilter() {
+			filter[common.ERUNodeName] = m.config.HostName
+			if m.storeIdentifier != "" {
+				filter[common.ERUCoreID] = m.storeIdentifier
+			}
+		}
+	})
+
+	return filter
 }

--- a/manager/workload/health_check.go
+++ b/manager/workload/health_check.go
@@ -29,7 +29,7 @@ func (m *Manager) healthCheck(ctx context.Context) {
 // 但是这时候 health check 刚返回 true 回来并写入 core
 // 为了保证最终数据一致性这里也要检测
 func (m *Manager) checkAllWorkloads(ctx context.Context) {
-	log.Debugf("[checkAllWorkloads] health check begin")
+	log.Debug("[checkAllWorkloads] health check begin")
 	workloadIDs, err := m.runtimeClient.ListWorkloadIDs(ctx, m.getBaseFilter())
 	if err != nil {
 		log.Errorf("[checkAllWorkloads] Error when list all workloads with label \"ERU=1\": %v", err)

--- a/manager/workload/health_check.go
+++ b/manager/workload/health_check.go
@@ -52,7 +52,7 @@ func (m *Manager) checkOneWorkload(ctx context.Context, ID string) bool {
 	}
 
 	if err = m.setWorkloadStatus(ctx, workloadStatus); err != nil {
-		log.Errorf("[checkOneWorkload] update workload status failed, err: %v", err)
+		log.Errorf("[checkOneWorkload] update workload status for %v failed, err: %v", ID, err)
 	}
 	return workloadStatus.Healthy
 }

--- a/manager/workload/health_check.go
+++ b/manager/workload/health_check.go
@@ -31,7 +31,7 @@ func (m *Manager) healthCheck(ctx context.Context) {
 // 为了保证最终数据一致性这里也要检测
 func (m *Manager) checkAllWorkloads(ctx context.Context) {
 	log.Debugf("[checkAllWorkloads] health check begin")
-	workloadIDs, err := m.runtimeClient.ListWorkloadIDs(ctx, true, nil)
+	workloadIDs, err := m.runtimeClient.ListWorkloadIDs(ctx, m.getBaseFilter())
 	if err != nil {
 		log.Errorf("[checkAllWorkloads] Error when list all workloads with label \"ERU=1\": %v", err)
 		return

--- a/manager/workload/load.go
+++ b/manager/workload/load.go
@@ -22,7 +22,7 @@ func (m *Manager) initWorkloadStatus(ctx context.Context) error {
 			defer wg.Done()
 			workloadStatus, err := m.runtimeClient.GetStatus(ctx, ID, true)
 			if err != nil {
-				log.Errorf("[initWorkloadStatus] get workload status failed %v", err)
+				log.Errorf("[initWorkloadStatus] get workload %v status failed %v", ID, err)
 				return
 			}
 

--- a/manager/workload/load.go
+++ b/manager/workload/load.go
@@ -4,21 +4,19 @@ import (
 	"context"
 	"sync"
 
-	coreutils "github.com/projecteru2/core/utils"
-
 	log "github.com/sirupsen/logrus"
 )
 
 func (m *Manager) load(ctx context.Context) error {
 	log.Info("[load] Load workloads")
-	workloadIDs, err := m.runtimeClient.ListWorkloadIDs(ctx, true, nil)
+	workloadIDs, err := m.runtimeClient.ListWorkloadIDs(ctx, m.getBaseFilter())
 	if err != nil {
 		return err
 	}
 
 	wg := &sync.WaitGroup{}
 	for _, wid := range workloadIDs {
-		log.Debugf("[load] detect workload %s", coreutils.ShortID(wid))
+		log.Debugf("[load] detect workload %s", wid)
 		wg.Add(1)
 		go func(ID string) {
 			defer wg.Done()

--- a/manager/workload/load.go
+++ b/manager/workload/load.go
@@ -7,8 +7,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (m *Manager) load(ctx context.Context) error {
-	log.Info("[load] Load workloads")
+func (m *Manager) initWorkloadStatus(ctx context.Context) error {
+	log.Info("[initWorkloadStatus] Load workloads")
 	workloadIDs, err := m.runtimeClient.ListWorkloadIDs(ctx, m.getBaseFilter())
 	if err != nil {
 		return err
@@ -16,24 +16,24 @@ func (m *Manager) load(ctx context.Context) error {
 
 	wg := &sync.WaitGroup{}
 	for _, wid := range workloadIDs {
-		log.Debugf("[load] detect workload %s", wid)
+		log.Debugf("[initWorkloadStatus] detect workload %s", wid)
 		wg.Add(1)
 		go func(ID string) {
 			defer wg.Done()
 			workloadStatus, err := m.runtimeClient.GetStatus(ctx, ID, true)
 			if err != nil {
-				log.Errorf("[load] get workload status failed %v", err)
+				log.Errorf("[initWorkloadStatus] get workload status failed %v", err)
 				return
 			}
 
 			if workloadStatus.Running {
-				log.Debugf("[load] workload %s is running", workloadStatus.ID)
+				log.Debugf("[initWorkloadStatus] workload %s is running", workloadStatus.ID)
 				go m.attach(ctx, ID)
 			}
 
 			// no health check here
 			if err := m.setWorkloadStatus(ctx, workloadStatus); err != nil {
-				log.Errorf("[load] update deploy status failed %v", err)
+				log.Errorf("[initWorkloadStatus] update workload %v status failed %v", ID, err)
 			}
 		}(wid)
 	}

--- a/manager/workload/load_test.go
+++ b/manager/workload/load_test.go
@@ -35,7 +35,7 @@ func TestLoad(t *testing.T) {
 	manager := newMockWorkloadManager(t)
 	store := manager.store.(*mocks.MockStore)
 	ctx := context.Background()
-	err := manager.load(ctx)
+	err := manager.initWorkloadStatus(ctx)
 	// wait for attaching
 	time.Sleep(2 * time.Second)
 	assert.Nil(t, err)

--- a/manager/workload/log.go
+++ b/manager/workload/log.go
@@ -139,7 +139,7 @@ func (l *logBroadcaster) run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			logrus.Infof("[logBroadcaster] stops")
+			logrus.Info("[logBroadcaster] stops")
 			return
 		case log := <-l.logC:
 			l.broadcast(log)

--- a/manager/workload/manager.go
+++ b/manager/workload/manager.go
@@ -131,8 +131,9 @@ func (m *Manager) Run(ctx context.Context) error {
 
 // PullLog pull logs for specific app
 func (m *Manager) PullLog(ctx context.Context, app string, buf *bufio.ReadWriter) {
-	ID, errChan := m.logBroadcaster.subscribe(app, buf)
-	defer m.logBroadcaster.unsubscribe(app, ID)
+	ID, errChan, unsubscribe := m.logBroadcaster.subscribe(ctx, app, buf)
+	defer unsubscribe()
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/manager/workload/manager.go
+++ b/manager/workload/manager.go
@@ -53,7 +53,7 @@ func NewManager(ctx context.Context, config *types.Config) (*Manager, error) {
 		corestore.Init(ctx, config)
 		manager.store = corestore.Get()
 		if manager.store == nil {
-			log.Errorf("[NewManager] failed to create core store client")
+			log.Error("[NewManager] failed to create core store client")
 			return nil, err
 		}
 	case common.MocksStore:
@@ -81,7 +81,7 @@ func NewManager(ctx context.Context, config *types.Config) (*Manager, error) {
 		docker.InitClient(config, manager.nodeIP)
 		manager.runtimeClient = docker.GetClient()
 		if manager.runtimeClient == nil {
-			log.Errorf("[NewManager] failed to create runtime client")
+			log.Error("[NewManager] failed to create runtime client")
 			return nil, err
 		}
 	case common.YavirtRuntime:

--- a/manager/workload/manager.go
+++ b/manager/workload/manager.go
@@ -105,26 +105,21 @@ func (m *Manager) Run(ctx context.Context) error {
 	// start log broadcaster
 	go m.logBroadcaster.run(ctx)
 
-	// load container
-	if err := m.load(ctx); err != nil {
+	// initWorkloadStatus container
+	if err := m.initWorkloadStatus(ctx); err != nil {
 		return err
 	}
+
 	// start status watcher
-	eventChan, errChan := m.initMonitor(ctx)
-	go m.monitor(ctx, eventChan)
+	go m.monitor(ctx)
 
 	// start health check
 	go m.healthCheck(ctx)
 
 	// wait for signal
-	select {
-	case <-ctx.Done():
-		log.Info("[WorkloadManager] exiting")
-		return nil
-	case err := <-errChan:
-		log.Infof("[WorkloadManager] failed to watch node status, err: %v", err)
-		return err
-	}
+	<-ctx.Done()
+	log.Info("[WorkloadManager] exiting")
+	return nil
 }
 
 // PullLog pull logs for specific app

--- a/manager/workload/manager.go
+++ b/manager/workload/manager.go
@@ -3,12 +3,14 @@ package workload
 import (
 	"bufio"
 	"context"
+	"errors"
 	"io"
 
 	"github.com/projecteru2/agent/common"
 	"github.com/projecteru2/agent/runtime"
 	"github.com/projecteru2/agent/runtime/docker"
 	runtimemocks "github.com/projecteru2/agent/runtime/mocks"
+	"github.com/projecteru2/agent/runtime/yavirt"
 	"github.com/projecteru2/agent/store"
 	corestore "github.com/projecteru2/agent/store/core"
 	storemocks "github.com/projecteru2/agent/store/mocks"
@@ -77,6 +79,12 @@ func NewManager(ctx context.Context, config *types.Config) (*Manager, error) {
 		if manager.runtimeClient == nil {
 			log.Errorf("[NewManager] failed to create runtime client")
 			return nil, err
+		}
+	case common.YavirtRuntime:
+		yavirt.InitClient(config)
+		manager.runtimeClient = yavirt.GetClient()
+		if manager.runtimeClient == nil {
+			return nil, errors.New("failed to get runtime client")
 		}
 	case common.MocksRuntime:
 		manager.runtimeClient = runtimemocks.FromTemplate()

--- a/manager/workload/monitor.go
+++ b/manager/workload/monitor.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/projecteru2/agent/common"
 	"github.com/projecteru2/agent/types"
-	coreutils "github.com/projecteru2/core/utils"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -16,8 +15,7 @@ func (m *Manager) initMonitor(ctx context.Context) (<-chan *types.WorkloadEventM
 	eventHandler.Handle(common.StatusStart, m.handleWorkloadStart)
 	eventHandler.Handle(common.StatusDie, m.handleWorkloadDie)
 
-	f := m.getFilter(map[string]string{})
-	eventChan, errChan := m.runtimeClient.Events(ctx, f)
+	eventChan, errChan := m.runtimeClient.Events(ctx, m.getBaseFilter())
 	return eventChan, errChan
 }
 
@@ -27,7 +25,7 @@ func (m *Manager) monitor(ctx context.Context, eventChan <-chan *types.WorkloadE
 }
 
 func (m *Manager) handleWorkloadStart(ctx context.Context, event *types.WorkloadEventMessage) {
-	log.Debugf("[handleWorkloadStart] workload %s start", coreutils.ShortID(event.ID))
+	log.Debugf("[handleWorkloadStart] workload %s start", event.ID)
 	workloadStatus, err := m.runtimeClient.GetStatus(ctx, event.ID, true)
 	if err != nil {
 		log.Errorf("[handleWorkloadStart] faild to get workload %v status, err: %v", event.ID, err)
@@ -48,7 +46,7 @@ func (m *Manager) handleWorkloadStart(ctx context.Context, event *types.Workload
 }
 
 func (m *Manager) handleWorkloadDie(ctx context.Context, event *types.WorkloadEventMessage) {
-	log.Debugf("[handleWorkloadDie] container %s die", coreutils.ShortID(event.ID))
+	log.Debugf("[handleWorkloadDie] container %s die", event.ID)
 	workloadStatus, err := m.runtimeClient.GetStatus(ctx, event.ID, true)
 	if err != nil {
 		log.Errorf("[handleWorkloadDie] faild to get workload %v status, err: %v", event.ID, err)

--- a/manager/workload/monitor.go
+++ b/manager/workload/monitor.go
@@ -34,7 +34,7 @@ func (m *Manager) monitor(ctx context.Context) {
 		go m.watchEvent(ctx, eventChan)
 		select {
 		case <-ctx.Done():
-			log.Infof("[monitor] context canceled, stop monitoring")
+			log.Info("[monitor] context canceled, stop monitoring")
 			return
 		case err := <-errChan:
 			log.Errorf("[monitor] received an err: %v, will retry", err)

--- a/runtime/docker/container.go
+++ b/runtime/docker/container.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/projecteru2/agent/utils"
 	coretypes "github.com/projecteru2/core/types"
-	coreutils "github.com/projecteru2/core/utils"
 )
 
 // Container docker container
@@ -32,8 +31,8 @@ func (c *Container) CheckHealth(ctx context.Context, timeout time.Duration) bool
 	if c.HealthCheck == nil {
 		return true
 	}
-	tcpChecker := []string{}
-	httpChecker := []string{}
+	var tcpChecker []string
+	var httpChecker []string
 
 	for _, port := range c.HealthCheck.TCPPorts {
 		tcpChecker = append(tcpChecker, fmt.Sprintf("%s:%s", c.LocalIP, port))
@@ -42,7 +41,7 @@ func (c *Container) CheckHealth(ctx context.Context, timeout time.Duration) bool
 		httpChecker = append(httpChecker, fmt.Sprintf("http://%s:%s%s", c.LocalIP, c.HealthCheck.HTTPPort, c.HealthCheck.HTTPURL))
 	}
 
-	ID := coreutils.ShortID(c.ID)
+	ID := c.ID
 	f1 := utils.CheckHTTP(ctx, ID, httpChecker, c.HealthCheck.HTTPCode, timeout)
 	f2 := utils.CheckTCP(ID, tcpChecker, timeout)
 	return f1 && f2

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -140,6 +140,9 @@ func (d *Docker) AttachWorkload(ctx context.Context, ID string) (io.Reader, io.R
 			resp.Close()
 			outw.Close()
 			errw.Close()
+			outr.Close()
+			errr.Close()
+			log.Debugf("[attach] %v buf pipes closed", ID)
 		}()
 
 		_, err = stdcopy.StdCopy(outw, errw, resp.Reader)

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -246,6 +246,7 @@ func (d *Docker) Events(ctx context.Context, filters map[string]string) (<-chan 
 				}
 			case err := <-e:
 				errChan <- err
+				return
 			case <-ctx.Done():
 				return
 			}
@@ -259,7 +260,7 @@ func (d *Docker) Events(ctx context.Context, filters map[string]string) (<-chan 
 func (d *Docker) GetStatus(ctx context.Context, ID string, checkHealth bool) (*types.WorkloadStatus, error) {
 	container, err := d.detectWorkload(ctx, ID)
 	if err != nil {
-		log.Errorf("[GetStatus] failed to detect workload, err: %v", err)
+		log.Errorf("[GetStatus] failed to detect workload %v, err: %v", ID, err)
 		return nil, err
 	}
 
@@ -312,7 +313,7 @@ func (d *Docker) GetWorkloadName(ctx context.Context, ID string) (string, error)
 func (d *Docker) LogFieldsExtra(ctx context.Context, ID string) (map[string]string, error) {
 	container, err := d.detectWorkload(ctx, ID)
 	if err != nil {
-		log.Errorf("[LogFieldsExtra] failed to detect container, err: %v", err)
+		log.Errorf("[LogFieldsExtra] failed to detect container %v, err: %v", ID, err)
 		return nil, err
 	}
 

--- a/runtime/docker/stat.go
+++ b/runtime/docker/stat.go
@@ -22,7 +22,7 @@ func (d *Docker) CollectWorkloadMetrics(ctx context.Context, ID string) {
 
 	container, err := d.detectWorkload(ctx, ID)
 	if err != nil {
-		log.Errorf("[CollectWorkloadMetrics] failed to detect container, err: %v", err)
+		log.Errorf("[CollectWorkloadMetrics] failed to detect container %v, err: %v", ID, err)
 	}
 
 	// init stats

--- a/runtime/docker/stat.go
+++ b/runtime/docker/stat.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/projecteru2/agent/utils"
-	coreutils "github.com/projecteru2/core/utils"
 
 	"github.com/shirou/gopsutil/net"
 	log "github.com/sirupsen/logrus"
@@ -29,7 +28,7 @@ func (d *Docker) CollectWorkloadMetrics(ctx context.Context, ID string) {
 	// init stats
 	containerCPUStats, systemCPUStats, containerNetStats, err := getStats(ctx, container.ID, container.Pid, proc)
 	if err != nil {
-		log.Errorf("[stat] get %s stats failed %v", coreutils.ShortID(container.ID), err)
+		log.Errorf("[stat] get %s stats failed %v", container.ID, err)
 		return
 	}
 
@@ -47,8 +46,8 @@ func (d *Docker) CollectWorkloadMetrics(ctx context.Context, ID string) {
 	hostCPUCount := d.cpuCore * period
 
 	mClient := NewMetricsClient(addr, hostname, container)
-	defer log.Infof("[stat] container %s %s metric report stop", container.Name, coreutils.ShortID(container.ID))
-	log.Infof("[stat] container %s %s metric report start", container.Name, coreutils.ShortID(container.ID))
+	defer log.Infof("[stat] container %s %s metric report stop", container.Name, container.ID)
+	log.Infof("[stat] container %s %s metric report start", container.Name, container.ID)
 
 	updateMetrics := func() {
 		newContainer, err := d.detectWorkload(ctx, container.ID)
@@ -61,12 +60,12 @@ func (d *Docker) CollectWorkloadMetrics(ctx context.Context, ID string) {
 		defer cancel()
 		newContainerCPUStats, newSystemCPUStats, newContainerNetStats, err := getStats(timeoutCtx, newContainer.ID, newContainer.Pid, proc)
 		if err != nil {
-			log.Errorf("[stat] get %s stats failed %v", coreutils.ShortID(newContainer.ID), err)
+			log.Errorf("[stat] get %s stats failed %v", newContainer.ID, err)
 			return
 		}
 		containerMemStats, err := getMemStats(timeoutCtx, newContainer.ID)
 		if err != nil {
-			log.Errorf("[stat] get %s mem stats failed %v", coreutils.ShortID(newContainer.ID), err)
+			log.Errorf("[stat] get %s mem stats failed %v", newContainer.ID, err)
 			return
 		}
 

--- a/runtime/mocks/Runtime.go
+++ b/runtime/mocks/Runtime.go
@@ -54,11 +54,11 @@ func (_m *Runtime) CollectWorkloadMetrics(ctx context.Context, ID string) {
 }
 
 // Events provides a mock function with given fields: ctx, filters
-func (_m *Runtime) Events(ctx context.Context, filters []types.KV) (<-chan *types.WorkloadEventMessage, <-chan error) {
+func (_m *Runtime) Events(ctx context.Context, filters map[string]string) (<-chan *types.WorkloadEventMessage, <-chan error) {
 	ret := _m.Called(ctx, filters)
 
 	var r0 <-chan *types.WorkloadEventMessage
-	if rf, ok := ret.Get(0).(func(context.Context, []types.KV) <-chan *types.WorkloadEventMessage); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, map[string]string) <-chan *types.WorkloadEventMessage); ok {
 		r0 = rf(ctx, filters)
 	} else {
 		if ret.Get(0) != nil {
@@ -67,7 +67,7 @@ func (_m *Runtime) Events(ctx context.Context, filters []types.KV) (<-chan *type
 	}
 
 	var r1 <-chan error
-	if rf, ok := ret.Get(1).(func(context.Context, []types.KV) <-chan error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, map[string]string) <-chan error); ok {
 		r1 = rf(ctx, filters)
 	} else {
 		if ret.Get(1) != nil {
@@ -136,13 +136,13 @@ func (_m *Runtime) IsDaemonRunning(ctx context.Context) bool {
 	return r0
 }
 
-// ListWorkloadIDs provides a mock function with given fields: ctx, all, filters
-func (_m *Runtime) ListWorkloadIDs(ctx context.Context, all bool, filters []types.KV) ([]string, error) {
-	ret := _m.Called(ctx, all, filters)
+// ListWorkloadIDs provides a mock function with given fields: ctx, filters
+func (_m *Runtime) ListWorkloadIDs(ctx context.Context, filters map[string]string) ([]string, error) {
+	ret := _m.Called(ctx, filters)
 
 	var r0 []string
-	if rf, ok := ret.Get(0).(func(context.Context, bool, []types.KV) []string); ok {
-		r0 = rf(ctx, all, filters)
+	if rf, ok := ret.Get(0).(func(context.Context, map[string]string) []string); ok {
+		r0 = rf(ctx, filters)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
@@ -150,8 +150,8 @@ func (_m *Runtime) ListWorkloadIDs(ctx context.Context, all bool, filters []type
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, bool, []types.KV) error); ok {
-		r1 = rf(ctx, all, filters)
+	if rf, ok := ret.Get(1).(func(context.Context, map[string]string) error); ok {
+		r1 = rf(ctx, filters)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/runtime/mocks/template.go
+++ b/runtime/mocks/template.go
@@ -86,21 +86,19 @@ func FromTemplate() runtime.Runtime {
 		nil,
 	)
 	n.On("CollectWorkloadMetrics", mock.Anything, mock.Anything).Return()
-	n.On("ListWorkloadIDs", mock.Anything, mock.Anything, mock.Anything).Return(func(ctx context.Context, all bool, filters []types.KV) []string {
+	n.On("ListWorkloadIDs", mock.Anything, mock.Anything).Return(func(ctx context.Context, filters map[string]string) []string {
 		var IDs []string
 		n.withLock(func() {
 			n.workloads.Range(func(ID, workload interface{}) bool {
-				if all || workload.(*eva).Running {
-					IDs = append(IDs, ID.(string))
-				}
+				IDs = append(IDs, ID.(string))
 				return true
 			})
 		})
 		return IDs
 	}, nil)
-	n.On("Events", mock.Anything, mock.Anything).Return(func(ctx context.Context, filters []types.KV) <-chan *types.WorkloadEventMessage {
+	n.On("Events", mock.Anything, mock.Anything).Return(func(ctx context.Context, filters map[string]string) <-chan *types.WorkloadEventMessage {
 		return n.msgChan
-	}, func(ctx context.Context, filters []types.KV) <-chan error {
+	}, func(ctx context.Context, filters map[string]string) <-chan error {
 		return n.errChan
 	})
 	n.On("GetStatus", mock.Anything, mock.Anything, mock.Anything).Return(func(ctx context.Context, ID string, checkHealth bool) *types.WorkloadStatus {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -11,8 +11,8 @@ import (
 type Runtime interface {
 	AttachWorkload(ctx context.Context, ID string) (io.Reader, io.Reader, error)
 	CollectWorkloadMetrics(ctx context.Context, ID string)
-	ListWorkloadIDs(ctx context.Context, all bool, filters []types.KV) ([]string, error)
-	Events(ctx context.Context, filters []types.KV) (<-chan *types.WorkloadEventMessage, <-chan error)
+	ListWorkloadIDs(ctx context.Context, filters map[string]string) ([]string, error)
+	Events(ctx context.Context, filters map[string]string) (<-chan *types.WorkloadEventMessage, <-chan error)
 	GetStatus(ctx context.Context, ID string, checkHealth bool) (*types.WorkloadStatus, error)
 	GetWorkloadName(ctx context.Context, ID string) (string, error)
 	LogFieldsExtra(ctx context.Context, ID string) (map[string]string, error)

--- a/runtime/yavirt/client.go
+++ b/runtime/yavirt/client.go
@@ -1,0 +1,30 @@
+package yavirt
+
+import (
+	"sync"
+
+	"github.com/projecteru2/agent/types"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	once   sync.Once
+	yavirt *Yavirt
+)
+
+// InitClient init yavirt client
+func InitClient(config *types.Config) {
+	once.Do(func() {
+		var err error
+		yavirt, err = New(config)
+		if err != nil {
+			log.Errorf("[InitClient] failed to create yavirt client, err: %v", err)
+		}
+	})
+}
+
+// GetClient .
+func GetClient() *Yavirt {
+	return yavirt
+}

--- a/runtime/yavirt/guest.go
+++ b/runtime/yavirt/guest.go
@@ -1,0 +1,93 @@
+package yavirt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/projecteru2/agent/utils"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// LabelMeta .
+const LabelMeta = "ERU_META"
+
+// HealthCheck .
+type HealthCheck struct {
+	TCPPorts []string
+	HTTPPort string
+	HTTPURL  string
+	HTTPCode int
+}
+
+type healthCheckBridge struct {
+	Publish     []string
+	HealthCheck *HealthCheck
+}
+
+// Guest yavirt virtual machine
+type Guest struct {
+	ID            string
+	Status        string
+	TransitStatus string
+	CreateTime    int64
+	TransitTime   int64
+	UpdateTime    int64
+	CPU           int
+	Mem           int64
+	Storage       int64
+	ImageID       int64
+	ImageName     string
+	ImageUser     string
+	Networks      map[string]string
+	Labels        map[string]string
+	IPList        []string
+	Hostname      string
+	Running       bool
+	HealthCheck   *HealthCheck
+
+	once sync.Once
+}
+
+// CheckHealth returns if the guest is healthy
+func (g *Guest) CheckHealth(ctx context.Context, timeout time.Duration) bool {
+	// init health check bridge
+	g.once.Do(func() {
+		if meta, ok := g.Labels[LabelMeta]; ok {
+			bridge := &healthCheckBridge{}
+			err := json.Unmarshal([]byte(meta), bridge)
+			if err != nil {
+				log.Errorf("[CheckHealth] invalid json format, guest %v, meta %v, err %v", g.ID, meta, err)
+				return
+			}
+			g.HealthCheck = bridge.HealthCheck
+		}
+	})
+
+	if g.HealthCheck == nil {
+		return true
+	}
+
+	var tcpChecker []string
+	var httpChecker []string
+
+	healthCheck := g.HealthCheck
+
+	for _, port := range healthCheck.TCPPorts {
+		for _, ip := range g.IPList {
+			tcpChecker = append(tcpChecker, fmt.Sprintf("%s:%s", ip, port))
+		}
+	}
+	if healthCheck.HTTPPort != "" {
+		for _, ip := range g.IPList {
+			httpChecker = append(httpChecker, fmt.Sprintf("http://%s:%s%s", ip, healthCheck.HTTPPort, healthCheck.HTTPURL))
+		}
+	}
+
+	f1 := utils.CheckHTTP(ctx, g.ID, httpChecker, healthCheck.HTTPCode, timeout)
+	f2 := utils.CheckTCP(g.ID, tcpChecker, timeout)
+	return f1 && f2
+}

--- a/runtime/yavirt/yavirt.go
+++ b/runtime/yavirt/yavirt.go
@@ -1,0 +1,228 @@
+package yavirt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/projecteru2/agent/common"
+	"github.com/projecteru2/agent/types"
+	"github.com/projecteru2/agent/utils"
+	"github.com/projecteru2/core/cluster"
+	"github.com/projecteru2/libyavirt/client"
+	yavirttypes "github.com/projecteru2/libyavirt/types"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Yavirt .
+type Yavirt struct {
+	client     client.Client
+	config     *types.Config
+	skipRegexp []*regexp.Regexp
+	cas        utils.GroupCAS
+}
+
+// New returns a wrapper of yavirt client
+func New(config *types.Config) (*Yavirt, error) {
+	y := &Yavirt{}
+	y.config = config
+
+	var err error
+	if y.client, err = utils.MakeYavirtClient(config); err != nil {
+		return nil, err
+	}
+
+	for _, expr := range y.config.Yavirt.SkipGuestReportRegexps {
+		reg, err := regexp.Compile(expr)
+		if err != nil {
+			log.Errorf("[NewYavirt] failed to compile regexp %v, err: %v", expr, err)
+			return nil, err
+		}
+		y.skipRegexp = append(y.skipRegexp, reg)
+	}
+
+	return y, nil
+}
+
+// needSkip checks if a workload should be skipped
+func (y *Yavirt) needSkip(ID string) bool {
+	for _, reg := range y.skipRegexp {
+		if reg.MatchString(ID) {
+			return true
+		}
+	}
+	return false
+}
+
+// detectWorkload detects a workload by ID
+func (y *Yavirt) detectWorkload(ctx context.Context, ID string) (*Guest, error) {
+	if y.needSkip(ID) {
+		return nil, fmt.Errorf("should skip this vm")
+	}
+
+	var guest yavirttypes.Guest
+	var err error
+
+	utils.WithTimeout(ctx, y.config.GlobalConnectionTimeout, func(ctx context.Context) {
+		guest, err = y.client.GetGuest(ctx, ID)
+	})
+
+	if err != nil {
+		log.Errorf("[detectWorkload] failed to detect workload %v, err: %v", ID, err)
+		return nil, err
+	}
+
+	if _, ok := guest.Labels[cluster.ERUMark]; !ok {
+		return nil, fmt.Errorf("not a eru vm %s", ID)
+	}
+
+	if y.config.CheckOnlyMine && y.config.HostName != guest.Hostname {
+		log.Debugf("[detectWorkload] guest's hostname is %s instead of %s", guest.Hostname, y.config.HostName)
+		return nil, fmt.Errorf("should ignore this vm")
+	}
+
+	return &Guest{
+		ID:            guest.ID,
+		Status:        guest.Status,
+		TransitStatus: guest.TransitStatus,
+		CreateTime:    guest.CreateTime,
+		TransitTime:   guest.TransitTime,
+		UpdateTime:    guest.UpdateTime,
+		CPU:           guest.CPU,
+		Mem:           guest.Mem,
+		Storage:       guest.Storage,
+		ImageID:       guest.ImageID,
+		ImageName:     guest.ImageName,
+		ImageUser:     guest.ImageUser,
+		Networks:      guest.Networks,
+		Labels:        guest.Labels,
+		IPList:        guest.IPList,
+		Hostname:      guest.Hostname,
+		Running:       guest.Running,
+		once:          sync.Once{},
+	}, nil
+}
+
+// AttachWorkload not implemented yet
+func (y *Yavirt) AttachWorkload(ctx context.Context, ID string) (io.Reader, io.Reader, error) {
+	return nil, nil, common.ErrNotImplemented
+}
+
+// CollectWorkloadMetrics no need yet
+func (y *Yavirt) CollectWorkloadMetrics(ctx context.Context, ID string) {}
+
+// ListWorkloadIDs lists workload IDs filtered by given condition
+func (y *Yavirt) ListWorkloadIDs(ctx context.Context, filters map[string]string) ([]string, error) {
+	var ids []string
+	var err error
+	utils.WithTimeout(ctx, y.config.GlobalConnectionTimeout, func(ctx context.Context) {
+		ids, err = y.client.GetGuestIDList(ctx, yavirttypes.GetGuestIDListReq{Filters: filters})
+	})
+	if err != nil {
+		log.Errorf("[ListWorkloadIDs] failed to get workload ids, err: %v", err)
+		return nil, err
+	}
+	return ids, nil
+}
+
+// Events returns the events of workloads' changes
+func (y *Yavirt) Events(ctx context.Context, filters map[string]string) (<-chan *types.WorkloadEventMessage, <-chan error) {
+	eventChan := make(chan *types.WorkloadEventMessage)
+	errChan := make(chan error)
+
+	var yaEventChan <-chan yavirttypes.EventMessage
+	var yaErrChan <-chan error
+
+	yaEventChan, yaErrChan = y.client.Events(ctx, filters)
+
+	go func() {
+		defer close(eventChan)
+		defer close(errChan)
+
+		for {
+			select {
+			case msg := <-yaEventChan:
+				eventChan <- &types.WorkloadEventMessage{
+					ID:       msg.ID,
+					Type:     msg.Type,
+					Action:   msg.Action,
+					TimeNano: msg.TimeNano,
+				}
+			case err := <-yaErrChan:
+				errChan <- err
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return eventChan, errChan
+}
+
+// GetStatus checks workload's status first, then returns workload status
+func (y *Yavirt) GetStatus(ctx context.Context, ID string, checkHealth bool) (*types.WorkloadStatus, error) {
+	guest, err := y.detectWorkload(ctx, ID)
+	if err != nil {
+		log.Errorf("[GetStatus] failed to get guest %v status, err: %v", ID, err)
+		return nil, err
+	}
+
+	bytes, err := json.Marshal(guest.Labels)
+	if err != nil {
+		log.Errorf("[GetStatus] failed to marshal labels, err: %v", err)
+		return nil, err
+	}
+
+	status := &types.WorkloadStatus{
+		ID:        guest.ID,
+		Running:   guest.Running,
+		Healthy:   guest.Running && guest.HealthCheck == nil,
+		Networks:  guest.Networks,
+		Extension: bytes,
+		Nodename:  y.config.HostName,
+	}
+
+	if checkHealth && guest.Running {
+		free, acquired := y.cas.Acquire(guest.ID)
+		if !acquired {
+			return nil, fmt.Errorf("[GetStatus] failed to get the lock")
+		}
+		defer free()
+		status.Healthy = guest.CheckHealth(ctx, time.Duration(y.config.HealthCheck.Timeout)*time.Second)
+	}
+
+	return status, nil
+}
+
+// GetWorkloadName not implemented yet
+func (y *Yavirt) GetWorkloadName(ctx context.Context, ID string) (string, error) {
+	return "", common.ErrNotImplemented
+}
+
+// LogFieldsExtra .
+func (y *Yavirt) LogFieldsExtra(ctx context.Context, ID string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+// IsDaemonRunning returns if the runtime daemon is running.
+func (y *Yavirt) IsDaemonRunning(ctx context.Context) bool {
+	var err error
+	utils.WithTimeout(ctx, y.config.GlobalConnectionTimeout, func(ctx context.Context) {
+		_, err = y.client.Info(ctx)
+	})
+	if err != nil {
+		log.Debugf("[IsDaemonRunning] connect to yavirt daemon failed, err: %v", err)
+		return false
+	}
+	return true
+}
+
+// Name returns the name of runtime
+func (y *Yavirt) Name() string {
+	return "yavirt"
+}

--- a/selfmon/node.go
+++ b/selfmon/node.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (m *Selfmon) initNodeStatus(ctx context.Context) {
-	log.Debugf("[selfmon] init node status started")
+	log.Debug("[selfmon] init node status started")
 	nodes := make(chan *types.Node)
 
 	go func() {
@@ -58,7 +58,7 @@ func (m *Selfmon) watchNodeStatus(ctx context.Context) {
 			time.Sleep(time.Second)
 			go m.initNodeStatus(ctx)
 			if m.watch(ctx) != nil {
-				log.Debugf("[selfmon] retry to watch node status")
+				log.Debug("[selfmon] retry to watch node status")
 				time.Sleep(m.config.GlobalConnectionTimeout)
 			}
 		}
@@ -67,8 +67,8 @@ func (m *Selfmon) watchNodeStatus(ctx context.Context) {
 
 func (m *Selfmon) watch(ctx context.Context) error {
 	messageChan, errChan := m.store.NodeStatusStream(ctx)
-	log.Debugf("[selfmon] watch node status started")
-	defer log.Debugf("[selfmon] stop watching node status")
+	log.Debug("[selfmon] watch node status started")
+	defer log.Debug("[selfmon] stop watching node status")
 
 	for {
 		select {
@@ -76,7 +76,7 @@ func (m *Selfmon) watch(ctx context.Context) error {
 			go m.dealNodeStatusMessage(ctx, message)
 		case err := <-errChan:
 			if err == io.EOF {
-				log.Debugf("[selfmon] server closed the stream")
+				log.Debug("[selfmon] server closed the stream")
 				return err
 			}
 			log.Debugf("[selfmon] read node status failed, err: %s", err)

--- a/selfmon/register.go
+++ b/selfmon/register.go
@@ -27,7 +27,7 @@ func (m *Selfmon) WithActiveLock(parentCtx context.Context, f func(ctx context.C
 	for {
 		select {
 		case <-ctx.Done():
-			log.Infof("[Register] context canceled")
+			log.Info("[Register] context canceled")
 			return
 		case <-m.Exit():
 			log.Infof("[Register] selfmon %v closed", m.id)
@@ -38,7 +38,7 @@ func (m *Selfmon) WithActiveLock(parentCtx context.Context, f func(ctx context.C
 		// try to get the lock
 		if ne, un, err := m.register(ctx); err != nil {
 			if errors.Is(err, context.Canceled) {
-				log.Infof("[Register] context canceled")
+				log.Info("[Register] context canceled")
 				return
 			} else if !errors.Is(err, coretypes.ErrKeyExists) {
 				log.Errorf("[Register] failed to re-register: %v", err)
@@ -61,13 +61,13 @@ func (m *Selfmon) WithActiveLock(parentCtx context.Context, f func(ctx context.C
 
 		select {
 		case <-ctx.Done():
-			log.Infof("[Register] context canceled")
+			log.Info("[Register] context canceled")
 			return
 		case <-m.Exit():
 			log.Infof("[Register] selfmon %v closed", m.id)
 			return
 		case <-expiry:
-			log.Infof("[Register] lock expired")
+			log.Info("[Register] lock expired")
 			return
 		}
 	}()

--- a/selfmon/selfmon.go
+++ b/selfmon/selfmon.go
@@ -51,7 +51,7 @@ func New(ctx context.Context, config *types.Config) (mon *Selfmon, err error) {
 			return nil, err
 		}
 	case common.MocksKV:
-		log.Debugf("[selfmon] use embedded ETCD")
+		log.Debug("[selfmon] use embedded ETCD")
 		mon.kv = nil
 	default:
 		return nil, errors.New("unknown kv type")
@@ -62,7 +62,7 @@ func New(ctx context.Context, config *types.Config) (mon *Selfmon, err error) {
 		corestore.Init(ctx, config)
 		mon.store = corestore.Get()
 		if mon.store == nil {
-			log.Errorf("[selfmon] failed to get core store")
+			log.Error("[selfmon] failed to get core store")
 			return nil, errors.New("failed to get core store")
 		}
 	case common.MocksStore:

--- a/store/core/rpcpool.go
+++ b/store/core/rpcpool.go
@@ -68,7 +68,7 @@ func NewCoreRPCClientPool(ctx context.Context, config *types.Config) (*ClientPoo
 	}
 
 	if allFailed {
-		log.Errorf("[NewCoreRPCClientPool] all connections failed")
+		log.Error("[NewCoreRPCClientPool] all connections failed")
 		return nil, errors.New("all connections failed")
 	}
 

--- a/types/config.go
+++ b/types/config.go
@@ -13,9 +13,15 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// DockerConfig contain endpoint
+// DockerConfig contain docker endpoint
 type DockerConfig struct {
-	Endpoint string `yaml:"endpoint" required:"true"`
+	Endpoint string `yaml:"endpoint" required:"false"`
+}
+
+// YavirtConfig contain yavirt endpoint
+type YavirtConfig struct {
+	Endpoint               string   `yaml:"endpoint" required:"false"`
+	SkipGuestReportRegexps []string `yaml:"skip_guest_report_regexps" required:"false"`
 }
 
 // MetricsConfig contain metrics config
@@ -56,8 +62,10 @@ type Config struct {
 	Runtime string `yaml:"runtime" default:"docker"`
 	KV      string `yaml:"kv" default:"etcd"`
 
-	Auth        coretypes.AuthConfig `yaml:"auth"`
-	Docker      DockerConfig
+	Auth   coretypes.AuthConfig `yaml:"auth"`
+	Docker DockerConfig
+	Yavirt YavirtConfig
+
 	Metrics     MetricsConfig
 	API         APIConfig `yaml:"api"`
 	Log         LogConfig

--- a/types/kv.go
+++ b/types/kv.go
@@ -1,7 +1,0 @@
-package types
-
-// KV key value pair
-type KV struct {
-	Key   string
-	Value string
-}

--- a/utils/bufpipe.go
+++ b/utils/bufpipe.go
@@ -121,5 +121,6 @@ func (w *PipeWriter) CloseWithError(err error) error {
 		err = io.EOF
 	}
 	w.rerr = err
+	w.cond.Signal()
 	return nil
 }

--- a/utils/bufpipe_test.go
+++ b/utils/bufpipe_test.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/docker/go-units"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"testing"
+	"time"
+)
+
+func TestBufPipe(t *testing.T)  {
+	size, _ := units.RAMInBytes("10M")
+	r, w := NewBufPipe(size)
+	w.Write([]byte("test"))
+	go func() {
+		time.Sleep(time.Second)
+		w.Close()
+		r.Close()
+	}()
+
+	reader := bufio.NewReader(r)
+
+	for {
+		_, err := reader.ReadString('\n')
+		if err != nil {
+			fmt.Println(err)
+			assert.Equal(t, err, io.EOF)
+			return
+		}
+	}
+}

--- a/utils/bufpipe_test.go
+++ b/utils/bufpipe_test.go
@@ -3,14 +3,15 @@ package utils
 import (
 	"bufio"
 	"fmt"
-	"github.com/docker/go-units"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"testing"
 	"time"
+
+	"github.com/docker/go-units"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestBufPipe(t *testing.T)  {
+func TestBufPipe(t *testing.T) {
 	size, _ := units.RAMInBytes("10M")
 	r, w := NewBufPipe(size)
 	w.Write([]byte("test"))

--- a/utils/check.go
+++ b/utils/check.go
@@ -29,6 +29,7 @@ func CheckTCP(ID string, backends []string, timeout time.Duration) bool {
 		log.Debugf("[checkTCP] Check health via tcp: workload %s, backend %s", ID, backend)
 		conn, err := net.DialTimeout("tcp", backend, timeout)
 		if err != nil {
+			log.Debugf("[checkTCP] Check health failed via tcp: workload %s, backend %s", ID, backend)
 			return false
 		}
 		conn.Close()

--- a/utils/check.go
+++ b/utils/check.go
@@ -13,9 +13,9 @@ import (
 // CheckHTTP 事实上一般也就一个
 func CheckHTTP(ctx context.Context, ID string, backends []string, code int, timeout time.Duration) bool {
 	for _, backend := range backends {
-		log.Debugf("[checkHTTP] Check health via http: container %s, url %s, expect code %d", ID, backend, code)
+		log.Debugf("[checkHTTP] Check health via http: workload %s, url %s, expect code %d", ID, backend, code)
 		if !checkOneURL(ctx, backend, code, timeout) {
-			log.Infof("[checkHTTP] Check health failed via http: container %s, url %s, expect code %d", ID, backend, code)
+			log.Infof("[checkHTTP] Check health failed via http: workload %s, url %s, expect code %d", ID, backend, code)
 			return false
 		}
 	}
@@ -26,7 +26,7 @@ func CheckHTTP(ctx context.Context, ID string, backends []string, code int, time
 // 这里不支持ctx?
 func CheckTCP(ID string, backends []string, timeout time.Duration) bool {
 	for _, backend := range backends {
-		log.Debugf("[checkTCP] Check health via tcp: container %s, backend %s", ID, backend)
+		log.Debugf("[checkTCP] Check health via tcp: workload %s, backend %s", ID, backend)
 		conn, err := net.DialTimeout("tcp", backend, timeout)
 		if err != nil {
 			return false

--- a/utils/retry.go
+++ b/utils/retry.go
@@ -32,7 +32,7 @@ func NewRetryTask(ctx context.Context, maxAttempts int, f func() error) *RetryTa
 
 // Run start running retry task
 func (r *RetryTask) Run() error {
-	log.Debugf("[RetryTask] start")
+	log.Debug("[RetryTask] start")
 	defer r.Stop()
 
 	var err error
@@ -43,7 +43,7 @@ func (r *RetryTask) Run() error {
 	for i := 0; i < r.MaxAttempts; i++ {
 		select {
 		case <-r.ctx.Done():
-			log.Debugf("[RetryTask] abort")
+			log.Debug("[RetryTask] abort")
 			return r.ctx.Err()
 		case <-timer.C:
 			err = r.Func()
@@ -60,7 +60,7 @@ func (r *RetryTask) Run() error {
 
 // Stop stops running task
 func (r *RetryTask) Stop() {
-	log.Debugf("[RetryTask] stop")
+	log.Debug("[RetryTask] stop")
 	r.cancel()
 }
 

--- a/utils/retry.go
+++ b/utils/retry.go
@@ -7,28 +7,66 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// BackoffRetry retries up to `maxAttempts` times, and the interval will grow exponentially
-func BackoffRetry(ctx context.Context, maxAttempts int, f func() error) error {
-	t := time.NewTimer(0)
-	var err error
+// RetryTask .
+type RetryTask struct {
+	ctx         context.Context
+	cancel      context.CancelFunc
+	Func        func() error
+	MaxAttempts int
+}
+
+// NewRetryTask .
+func NewRetryTask(ctx context.Context, maxAttempts int, f func() error) *RetryTask {
 	// make sure to execute at least once
 	if maxAttempts < 1 {
 		maxAttempts = 1
 	}
-	interval := 1
+	ctx, cancel := context.WithCancel(ctx)
+	return &RetryTask{
+		ctx:         ctx,
+		cancel:      cancel,
+		MaxAttempts: maxAttempts,
+		Func:        f,
+	}
+}
 
-	for i := 0; i < maxAttempts; i++ {
+// Run start running retry task
+func (r *RetryTask) Run() error {
+	log.Debugf("[RetryTask] start")
+	defer r.Stop()
+
+	var err error
+	interval := 1
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+
+	for i := 0; i < r.MaxAttempts; i++ {
 		select {
-		case <-t.C:
-			if err = f(); err == nil {
+		case <-r.ctx.Done():
+			log.Debugf("[RetryTask] abort")
+			return r.ctx.Err()
+		case <-timer.C:
+			err = r.Func()
+			if err == nil {
 				return nil
 			}
-			log.Debugf("[backoffRetry] will retry after %d seconds", interval)
-			t.Reset(time.Duration(interval) * time.Second)
+			log.Debugf("[RetryTask] will retry after %v seconds", interval)
+			timer.Reset(time.Duration(interval) * time.Second)
 			interval *= 2
-		case <-ctx.Done():
-			return ctx.Err()
 		}
 	}
 	return err
+}
+
+// Stop stops running task
+func (r *RetryTask) Stop() {
+	log.Debugf("[RetryTask] stop")
+	r.cancel()
+}
+
+// BackoffRetry retries up to `maxAttempts` times, and the interval will grow exponentially
+func BackoffRetry(ctx context.Context, maxAttempts int, f func() error) error {
+	retryTask := NewRetryTask(ctx, maxAttempts, f)
+	defer retryTask.Stop()
+	return retryTask.Run()
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -18,6 +18,7 @@ import (
 	"github.com/projecteru2/agent/types"
 	"github.com/projecteru2/agent/version"
 	coreutils "github.com/projecteru2/core/utils"
+	yavirtclient "github.com/projecteru2/libyavirt/client"
 
 	engineapi "github.com/docker/docker/client"
 	log "github.com/sirupsen/logrus"
@@ -27,6 +28,11 @@ import (
 func MakeDockerClient(config *types.Config) (*engineapi.Client, error) {
 	defaultHeaders := map[string]string{"User-Agent": fmt.Sprintf("eru-agent-%s", version.VERSION)}
 	return engineapi.NewClient(config.Docker.Endpoint, common.DockerCliVersion, nil, defaultHeaders)
+}
+
+// MakeYavirtClient make a yavirt client
+func MakeYavirtClient(config *types.Config) (yavirtclient.Client, error) {
+	return yavirtclient.New(config.Yavirt.Endpoint)
 }
 
 // WritePid write pid
@@ -52,21 +58,6 @@ func Max(a, b int64) int64 {
 // UseLabelAsFilter return if use label as filter
 func UseLabelAsFilter() bool {
 	return os.Getenv("ERU_AGENT_EXPERIMENTAL_FILTER") == "label"
-}
-
-// CheckHostname check if ERU_NODE_NAME env in container is the hostname of this agent
-// TODO should be removed in the future, should always use label to filter
-func CheckHostname(env []string, hostname string) bool {
-	for _, e := range env {
-		ps := strings.SplitN(e, "=", 2)
-		if len(ps) != 2 {
-			continue
-		}
-		if ps[0] == "ERU_NODE_NAME" && ps[1] == hostname {
-			return true
-		}
-	}
-	return false
 }
 
 // GetMaxAttemptsByTTL .

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -156,15 +156,6 @@ func TestUseLabelAsFilter(t *testing.T) {
 	assert.Equal(t, UseLabelAsFilter(), true)
 }
 
-func TestCheckHostname(t *testing.T) {
-	env := []string{"ERU_NODE_NAME=hostname", "LUNCH=free", "ANNUAL_LEAVE=unlimited"}
-	assert.Equal(t, CheckHostname(env, "hostname"), true)
-	assert.Equal(t, CheckHostname(env, ""), false)
-
-	env = []string{"LUNCH=free", "ANNUAL_LEAVE=unlimited"}
-	assert.Equal(t, CheckHostname(env, ""), false)
-}
-
 func TestGetMaxAttemptsByTTL(t *testing.T) {
 	assert.Equal(t, GetMaxAttemptsByTTL(0), 5) // selfmon enabled
 	assert.Equal(t, GetMaxAttemptsByTTL(1), 2)


### PR DESCRIPTION
除了Yavirt相关，本次PR也修了一些历史遗留bug和这次重构新产生的bug：

优化：Runtime daemon退出时会导致agent整体退出的问题
修复：Bufpipe在特殊情况下Read会无限阻塞的问题
修复：logs/Writer内的重试机制可能会导致goroutine数量爆炸的问题
修复：容器无限重启时，backoff retry可能会导致goroutine数量爆炸的问题
修复：容器无限重启时，logBroadcaster可能会阻塞的问题

-----------------

突然发现我之前getFilter的用法有点问题。

在Docker里，filter应该是这样的格式：{Key: "label", Value: "ERU=1"}
而Yavirt里需要自己手动实现这块，在ETCD里把labels解析出来，所以Yavirt需要的格式是：{Key: "ERU", Value: "1"}

所以应该在manager的层面实现一个`getBaseFilter`，返回的是常规的键值对。如果Runtime层面想要对labels进行特殊处理的话，自己手动转换一下。

以及重构前的版本`getFilter`有一个extend参数，我感觉没什么用，给去掉了。

types.KV全部替换为map[string]string，当初为了应对docker里key可能重复（都叫"label"）的时候引入的。