### PR TITLE
push image to github packages

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -14,7 +14,16 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: build and push
+      - name: build and push to github packages
+        uses: docker/build-push-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          tag_with_ref: true
+          tag_with_sha: false
+
+      - name: build and push to docker hub
         uses: docker/build-push-action@v1
         with:
           repository: projecteru2/agent
@@ -23,11 +32,21 @@ jobs:
           tag_with_ref: true
           tag_with_sha: false
 
-      - name: "[debug version] build and push"
+      - name: "[debug version] build and push to docker hub"
         uses: docker/build-push-action@v1
         with:
           build_args: KEEP_SYMBOL=1
           repository: projecteru2/agent
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: ${{ github.sha }}-debug
+
+      - name: "[debug version] build and push to github packages"
+        uses: docker/build-push-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          build_args: KEEP_SYMBOL=1
+          repository: projecteru2/agent
           tags: ${{ github.sha }}-debug

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.17
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
打tag的时候也构建一份镜像传送到github packages，顺便把go的版本换成了1.17。

在我自己分支测试的时候，可以顺利上传到github packages，但是docker hub不行（因为我没有projecteru2/agent的权限）。因为docker hub这块我也没改，默认它还是能用的8。