### PR TITLE
unit tests

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -48,5 +48,4 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           build_args: KEEP_SYMBOL=1
-          repository: projecteru2/agent
           tags: ${{ github.sha }}-debug

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ binary:
 
 unit-test:
 	go vet `go list ./... | grep -v '/vendor/'`
-	go test -race -count=1 -cover ./logs/... \
+	go test -race -count=1 -timeout 240s -cover ./logs/... \
 	./manager/node/... \
 	./manager/workload/... \
 	./selfmon/... \

--- a/logs/writer.go
+++ b/logs/writer.go
@@ -65,6 +65,8 @@ func NewWriter(ctx context.Context, addr string, stdout bool) (writer *Writer, e
 	case err == common.ErrInvalidScheme:
 		log.Infof("[writer] create an empty writer for %s success", addr)
 		writer.enc = NewStreamEncoder(discard{})
+	case err == errJournalDisabled:
+		return nil, err
 	case err != nil:
 		log.Errorf("[writer] failed to create writer encoder for %s, err: %v, will retry", addr, err)
 		writer.needReconnect = true

--- a/manager/workload/attach.go
+++ b/manager/workload/attach.go
@@ -96,7 +96,6 @@ func (m *Manager) attach(ctx context.Context, ID string) {
 			}
 			if err := writer.Write(l); err != nil && !(entryPoint == "agent" && utils.IsDockerized()) {
 				log.Errorf("[attach] %s workload %s_%s write failed %v", workloadName, entryPoint, ID, err)
-				log.Errorf("[attach] %s", data)
 			}
 		}
 	}

--- a/manager/workload/load.go
+++ b/manager/workload/load.go
@@ -31,7 +31,6 @@ func (m *Manager) initWorkloadStatus(ctx context.Context) error {
 				go m.attach(ctx, ID)
 			}
 
-			// no health check here
 			if err := m.setWorkloadStatus(ctx, workloadStatus); err != nil {
 				log.Errorf("[initWorkloadStatus] update workload %v status failed %v", ID, err)
 			}

--- a/manager/workload/log.go
+++ b/manager/workload/log.go
@@ -128,7 +128,6 @@ func (l *logBroadcaster) broadcast(log *types.Log) {
 				sub.errChan <- err
 				return
 			}
-
 			sub.buf.Flush()
 		}(ID, sub)
 	}

--- a/manager/workload/manager_test.go
+++ b/manager/workload/manager_test.go
@@ -41,6 +41,12 @@ func TestRun(t *testing.T) {
 	runtime := manager.runtimeClient.(*mocks.Nerv)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
-	go runtime.StartEvents()
+	go func() {
+		runtime.StartEvents()
+		runtime.StartCustomEvent(&types.WorkloadEventMessage{
+			ID:     "Kaworu",
+			Action: "start",
+		})
+	}()
 	assert.Nil(t, manager.Run(ctx))
 }

--- a/runtime/mocks/template.go
+++ b/runtime/mocks/template.go
@@ -106,6 +106,7 @@ func FromTemplate() runtime.Runtime {
 		n.withLock(func() {
 			v, ok := n.workloads.Load(ID)
 			if !ok {
+				status = &types.WorkloadStatus{ID: ID}
 				return
 			}
 			workload := v.(*eva)
@@ -177,6 +178,11 @@ func (n *Nerv) StartEvents() {
 		ID:     "Rei",
 		Action: common.StatusDie,
 	}
+}
+
+// StartCustomEvent .
+func (n *Nerv) StartCustomEvent(event *types.WorkloadEventMessage) {
+	n.msgChan <- event
 }
 
 // SetDaemonRunning set `daemonRunning`

--- a/selfmon/selfmon_test.go
+++ b/selfmon/selfmon_test.go
@@ -116,12 +116,14 @@ func TestRun(t *testing.T) {
 	store := m.store.(*storemocks.MockStore)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	exit := make(chan struct{})
 
 	// set node "fake" as alive
 	assert.Nil(t, store.SetNodeStatus(ctx, 0))
 
 	go func() {
 		assert.Nil(t, m.Run(ctx))
+		exit <- struct{}{}
 	}()
 	time.Sleep(2 * time.Second)
 
@@ -138,5 +140,7 @@ func TestRun(t *testing.T) {
 	node, _ = store.GetNode(ctx, "faker")
 	assert.Equal(t, node.Available, true)
 
+	store.StopNodeStatusStream()
 	m.Close()
+	<-exit
 }

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -31,4 +31,6 @@ func TestLoadConfig(t *testing.T) {
 
 	assert.Equal(config.GlobalConnectionTimeout, time.Second*15)
 	assert.Equal(config.HAKeepaliveInterval, time.Second*16)
+
+	config.Print()
 }

--- a/utils/check_test.go
+++ b/utils/check_test.go
@@ -12,11 +12,14 @@ import (
 func TestCheck(t *testing.T) {
 	go http.ListenAndServe(":12306", http.NotFoundHandler())
 	time.Sleep(time.Second)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 	assert.Equal(t, CheckHTTP(ctx, "", []string{"http://127.0.0.1:12306"}, 404, time.Second), true)
 	assert.Equal(t, CheckHTTP(ctx, "", []string{"http://127.0.0.1:12306"}, 0, time.Second), true)
 	assert.Equal(t, CheckHTTP(ctx, "", []string{"http://127.0.0.1:12306"}, 200, time.Second), false)
 	assert.Equal(t, CheckHTTP(ctx, "", []string{"http://127.0.0.1:12307"}, 200, time.Second), false)
+
+	cancel()
+	assert.Equal(t, CheckHTTP(ctx, "", []string{"http://127.0.0.1:12306"}, 404, time.Second), false)
 
 	assert.Equal(t, CheckTCP("", []string{"127.0.0.1:12306"}, time.Second), true)
 	assert.Equal(t, CheckTCP("", []string{"127.0.0.1:12307"}, time.Second), false)

--- a/utils/hash_test.go
+++ b/utils/hash_test.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHashBackend(t *testing.T) {
+	data := []string{
+		"s1",
+		"s2",
+	}
+	backend := NewHashBackends(data)
+	assert.EqualValues(t, backend.Len(), 2)
+	// a certain string will always get a certain hash
+	assert.Equal(t, backend.Get("param1", 0), "s2")
+	assert.Equal(t, backend.Get("param2", 0), "s1")
+}

--- a/utils/retry_test.go
+++ b/utils/retry_test.go
@@ -4,19 +4,42 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestBackoffRetry(t *testing.T) {
+	var errNotSuccess = errors.New("not success")
 	i := 0
 	f := func() error {
 		i++
 		if i < 4 {
-			return errors.New("xxx")
+			return errNotSuccess
 		}
 		return nil
 	}
 	assert.Nil(t, BackoffRetry(context.Background(), 10, f))
 	assert.Equal(t, 4, i)
+
+	i = 0
+	assert.Equal(t, errNotSuccess, BackoffRetry(context.Background(), 0, f))
+	assert.Equal(t, 1, i)
+}
+
+func TestBackoffRetryWithCancel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var errNotSuccess = errors.New("not success")
+	i := 0
+	f := func() error {
+		i++
+		if i < 4 {
+			return errNotSuccess
+		}
+		return nil
+	}
+	assert.Equal(t, context.DeadlineExceeded, BackoffRetry(ctx, 10, f))
+	assert.NotEqual(t, 4, i)
 }

--- a/utils/sync.go
+++ b/utils/sync.go
@@ -2,28 +2,7 @@ package utils
 
 import (
 	"sync"
-	"sync/atomic"
 )
-
-// AtomicBool indicates an atomic boolean instance.
-type AtomicBool struct {
-	i32 int32
-}
-
-// Bool .
-func (a *AtomicBool) Bool() bool {
-	return atomic.LoadInt32(&a.i32) == 1
-}
-
-// Set to true.
-func (a *AtomicBool) Set() {
-	atomic.StoreInt32(&a.i32, 1)
-}
-
-// Unset to false.
-func (a *AtomicBool) Unset() {
-	atomic.StoreInt32(&a.i32, 0)
-}
 
 // GroupCAS indicates cas locks which are grouped by keys.
 type GroupCAS struct {


### PR DESCRIPTION
完善了一下agent的单元测试，尽量刷了一波覆盖率，能用mock测到的重点逻辑基本都覆盖了。

有些地方的覆盖率就不太好刷，比如types.Config.Prepare，导致types只有15%左右的覆盖率...再比如代码里判断runtime / store类型的分支判断，因为单元测试里用的都是mocks，不可避免地docker / yavirt / grpc这些分支就没有覆盖到，我姑且认为这样是合理的...