### PR TITLE
[SPVR-121] Update time exceeded expected duration when updating network config

### DIFF
--- a/store/core/workload.go
+++ b/store/core/workload.go
@@ -19,7 +19,7 @@ func getCacheTTL(ttl int) time.Duration {
 
 // SetWorkloadStatus deploy containers
 func (c *Store) SetWorkloadStatus(ctx context.Context, status *types.WorkloadStatus, ttl int64) error {
-	workloadStatus := fmt.Sprintf("%s|%v|%v", status.ID, status.Running, status.Healthy)
+	workloadStatus := fmt.Sprintf("%+v", status)
 	if ttl == 0 {
 		cached, ok := c.cache.Get(status.ID)
 		if ok {


### PR DESCRIPTION
由于现在SetWorkloadStatus里的local cache没有保存除了 ID/Running/Healthy 以外的其他信息，所以当Networks发生变化的时候，agent不会及时上报，而是要等local cache过期了之后才会上报（默认是300秒）。

现在把所有字段都塞缓存里了，这样任意字段变动都可以触发上报。