### PR TITLE
user "Ping" to test if dockerd is running

### DIFF
--- a/manager/node/heartbeat.go
+++ b/manager/node/heartbeat.go
@@ -40,14 +40,14 @@ func (m *Manager) nodeStatusReport(ctx context.Context) {
 	defer log.Debug("[nodeStatusReport] report ends")
 
 	if !m.runtimeClient.IsDaemonRunning(ctx) {
-		log.Debug("[nodeStatusReport] cannot connect to runtime daemon")
+		log.Error("[nodeStatusReport] cannot connect to runtime daemon")
 		return
 	}
 
 	ttl := int64(m.config.HeartbeatInterval * 3)
 
 	err := utils.BackoffRetry(ctx, 3, func() (err error) {
-		utils.WithTimeout(ctx, time.Duration(m.config.HealthCheck.Timeout)*time.Second, func(ctx context.Context) {
+		utils.WithTimeout(ctx, m.config.GlobalConnectionTimeout, func(ctx context.Context) {
 			if err = m.store.SetNodeStatus(ctx, ttl); err != nil {
 				log.Errorf("[nodeStatusReport] failed to set node status of %v, err %v", m.config.HostName, err)
 			}

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -335,10 +335,10 @@ func (d *Docker) LogFieldsExtra(ctx context.Context, ID string) (map[string]stri
 func (d *Docker) IsDaemonRunning(ctx context.Context) bool {
 	var err error
 	utils.WithTimeout(ctx, d.config.GlobalConnectionTimeout, func(ctx context.Context) {
-		_, err = d.client.Info(ctx)
+		_, err = d.client.Ping(ctx)
 	})
 	if err != nil {
-		log.Debugf("[IsDaemonRunning] connect to docker daemon failed, err: %v", err)
+		log.Errorf("[IsDaemonRunning] connect to docker daemon failed, err: %v", err)
 		return false
 	}
 	return true


### PR DESCRIPTION
之前用Info来检查dockerd的可用性，但是这个api太重了，容易超时，导致agent觉得dockerd挂了，最终node status过期。换成轻量级的ping会更合理一些。