### PR TITLE
update github action

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -12,42 +12,58 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: build and push to github packages
-        uses: docker/build-push-action@v1
+      - name: Log in to the ghcr
+        uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          tag_with_ref: true
-          tag_with_sha: false
 
-      - name: build and push to docker hub
-        uses: docker/build-push-action@v1
+      - name: Log in to the docker
+        uses: docker/login-action@v1
         with:
-          repository: projecteru2/agent
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          tag_with_ref: true
-          tag_with_sha: false
 
-      - name: "[debug version] build and push to docker hub"
-        uses: docker/build-push-action@v1
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
         with:
-          build_args: KEEP_SYMBOL=1
-          repository: projecteru2/agent
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          tags: ${{ github.sha }}-debug
+          images: |
+            ghcr.io/${{ github.repository }}
+            ${{ github.repository }}
+          tags: |
+            type=ref,event=tag
 
-      - name: "[debug version] build and push to github packages"
-        uses: docker/build-push-action@v1
+      - name: Docker meta for debug version
+        if: ${{ github.ref == 'refs/heads/master' }}
+        id: debug-meta
+        uses: docker/metadata-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          build_args: KEEP_SYMBOL=1
-          tags: ${{ github.sha }}-debug
+          images: |
+            ghcr.io/${{ github.repository }}
+            ${{ github.repository }}
+          tags: |
+            type=sha,format=long,prefix=
+
+      - name: Build and push image
+        if: ${{ steps.meta.outputs.tags != '' }}
+        uses: docker/build-push-action@v2
+        with:
+          context: "."
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+
+      - name: "[debug version] Build and push image"
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: docker/build-push-action@v2
+        with:
+          context: "."
+          push: true
+          build-args: |
+            KEEP_SYMBOL=1
+          tags: ${{ steps.debug-meta.outputs.tags }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v3
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.40
+          version: v1.44.2
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.17.7
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,6 @@ jobs:
     container: projecteru2/footstone:latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: unit tests
         run: make test


### PR DESCRIPTION
针对github action的一些改动：
1. 升级actions和一些其它工具的版本
2. 以前latest是最新的master，现在latest是最新的tag
3. 每个master的更新都会触发一个debug版本的构建（带符号表），但是tag更新不会